### PR TITLE
Feature/complete image management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "smp"
 version = "0"
 description = "Simple Management Protocol (SMP) for remotely managing MCU firmware"
-authors = ["J.P. Hutchins <jphutchins@gmail.com>"]
+authors = [
+    "J.P. Hutchins <jphutchins@gmail.com>",
+    "J.P. Hutchins <jp@intercreate.io>"
+]
 readme = "README.md"
 license = "Apache-2.0"
 packages = [

--- a/smp/image_management.py
+++ b/smp/image_management.py
@@ -87,6 +87,17 @@ class ImageUploadFinalWriteResponse(_ImageManagementGroup, message.WriteResponse
     match: bool | None = None
 
 
+class ImageEraseRequest(_ImageManagementGroup, message.WriteRequest):
+    _COMMAND_ID = header.CommandId.ImageManagement.ERASE
+
+    slot: int | None = None
+    """The slot to erase. If not provided, slot 1 will be erased."""
+
+
+class ImageEraseResponse(_ImageManagementGroup, message.WriteResponse):
+    _COMMAND_ID = header.CommandId.ImageManagement.ERASE
+
+
 @unique
 class IMG_MGMT_ERR(IntEnum):
     OK = 0

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -120,3 +120,60 @@ def test_ImageStatesReadResponse(
     )
     assert_header(r3)
     assert_response(r3)
+
+
+def test_ImageEraseRequest() -> None:
+    assert_header = make_assert_header(
+        smpheader.GroupId.IMAGE_MANAGEMENT,
+        smpheader.OP.WRITE,
+        smpheader.CommandId.ImageManagement.ERASE,
+        1,  # empty map
+    )
+    r = smpimg.ImageEraseRequest()
+
+    assert_header(r)
+    assert smpheader.Header.SIZE + 1 == len(r.BYTES)
+
+    r = smpimg.ImageEraseRequest.loads(r.BYTES)
+    assert_header(r)
+    assert smpheader.Header.SIZE + 1 == len(r.BYTES)
+
+    r = smpimg.ImageEraseRequest.load(cast(smpheader.Header, r.header), {})
+    assert_header(r)
+    assert smpheader.Header.SIZE + 1 == len(r.BYTES)
+
+    assert_header = make_assert_header(
+        smpheader.GroupId.IMAGE_MANAGEMENT,
+        smpheader.OP.WRITE,
+        smpheader.CommandId.ImageManagement.ERASE,
+        None,
+    )
+    r = smpimg.ImageEraseRequest(slot=0)
+
+    assert_header(r)
+    assert r.slot == 0
+
+    r = smpimg.ImageEraseRequest.loads(r.BYTES)
+    assert_header(r)
+    assert r.slot == 0
+
+
+def test_ImageEraseResponse() -> None:
+    assert_header = make_assert_header(
+        smpheader.GroupId.IMAGE_MANAGEMENT,
+        smpheader.OP.WRITE_RSP,
+        smpheader.CommandId.ImageManagement.ERASE,
+        1,  # empty map
+    )
+    r = smpimg.ImageEraseResponse()
+
+    assert_header(r)
+    assert smpheader.Header.SIZE + 1 == len(r.BYTES)
+
+    r = smpimg.ImageEraseResponse.loads(r.BYTES)
+    assert_header(r)
+    assert smpheader.Header.SIZE + 1 == len(r.BYTES)
+
+    r = smpimg.ImageEraseResponse.load(cast(smpheader.Header, r.header), {})
+    assert_header(r)
+    assert smpheader.Header.SIZE + 1 == len(r.BYTES)


### PR DESCRIPTION
This adds the last command, Image Erase, from the SMP Image Management Group: https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-erase