### PR TITLE
BREAKING CHANGE: fix #13: move Intercreate group ID out of GroupID enum

### DIFF
--- a/smp/header.py
+++ b/smp/header.py
@@ -40,6 +40,7 @@ class CommandId:
 AnyCommandId: TypeAlias = IntEnum | int
 
 
+@unique
 class GroupId(IntEnum):
     OS_MANAGEMENT = 0
     IMAGE_MANAGEMENT = 1
@@ -52,7 +53,13 @@ class GroupId(IntEnum):
     FILE_MANAGEMENT = 8
     SHELL_MANAGEMENT = 9
     ZEPHYR = 63
-    _APPLICATIION_CUSTOM_MIN = 64
+
+
+class UserGroupId(IntEnum):
+    """Users may define their own Group IDs starting at 64.
+
+    It is optional to register them here."""
+
     INTERCREATE = 64
 
 
@@ -94,7 +101,7 @@ class Header:
     version: Version
     flags: Flag
     length: int
-    group_id: AnyGroupId | GroupId
+    group_id: AnyGroupId | GroupId | UserGroupId
     sequence: int
     command_id: (
         AnyCommandId
@@ -108,7 +115,6 @@ class Header:
         GroupId.OS_MANAGEMENT: CommandId.OSManagement,
         GroupId.IMAGE_MANAGEMENT: CommandId.ImageManagement,
         GroupId.SHELL_MANAGEMENT: CommandId.ShellManagement,
-        GroupId.INTERCREATE: CommandId.Intercreate,
     }
     _STRUCT: ClassVar = struct.Struct("!BBHHBB")
     SIZE: ClassVar = _STRUCT.size

--- a/smp/message.py
+++ b/smp/message.py
@@ -23,7 +23,7 @@ class _MessageBase(ABC, BaseModel):
     _OP: ClassVar[smpheader.OP]
     _VERSION: ClassVar[smpheader.Version] = smpheader.Version.V0
     _FLAGS: ClassVar[smpheader.Flag] = smpheader.Flag(0)
-    _GROUP_ID: ClassVar[smpheader.GroupId | smpheader.AnyGroupId]
+    _GROUP_ID: ClassVar[smpheader.GroupId | smpheader.UserGroupId | smpheader.AnyGroupId]
     _COMMAND_ID: ClassVar[
         smpheader.AnyCommandId
         | smpheader.CommandId.ImageManagement

--- a/smp/user/intercreate.py
+++ b/smp/user/intercreate.py
@@ -7,7 +7,7 @@ from smp import error, header, message
 
 
 class _IntercreateManagementGroup:
-    _GROUP_ID: ClassVar = header.GroupId.INTERCREATE
+    _GROUP_ID: ClassVar = header.UserGroupId.INTERCREATE
 
 
 class ImageUploadWriteRequest(_IntercreateManagementGroup, message.WriteRequest):
@@ -46,8 +46,8 @@ class IC_MGMT_ERR(IntEnum):
 
 
 class ErrorV0(error.ErrorV0[IC_MGMT_ERR]):
-    _GROUP_ID = header.GroupId.INTERCREATE
+    _GROUP_ID = header.UserGroupId.INTERCREATE
 
 
 class ErrorV1(error.ErrorV1[IC_MGMT_ERR]):
-    _GROUP_ID = header.GroupId.INTERCREATE
+    _GROUP_ID = header.UserGroupId.INTERCREATE

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ from smp.message import _MessageBase
 
 
 def make_assert_header(
-    group_id: smpheader.GroupId,
+    group_id: smpheader.GroupId | smpheader.UserGroupId,
     op: smpheader.OP,
     command_id: smpheader.AnyCommandId,
     length: int | None,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -2,27 +2,54 @@
 
 
 import struct
+from enum import IntEnum
 from typing import Final, Type
 
 import pytest
 
-from smp import header as smphdr
 from smp import message as smpmsg
 
-GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM: Final = 65
-assert GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM not in list(smphdr.GroupId)
+USER_GROUP_ID_MIN: Final = 64
 
 
 def test_custom_ReadRequest() -> None:
     """Test ReadRequest inheritance."""
 
-    class CustomInts(smpmsg.ReadRequest):
-        _GROUP_ID = GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM
+    class A(smpmsg.ReadRequest):
+        _GROUP_ID = USER_GROUP_ID_MIN
         _COMMAND_ID = 0
 
-    m = CustomInts()
-    assert m._GROUP_ID == GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM
-    assert m._COMMAND_ID == 0
+    a = A()
+    assert a._GROUP_ID == USER_GROUP_ID_MIN
+    assert a._COMMAND_ID == 0
+
+    class B(smpmsg.ReadRequest):
+        _GROUP_ID = 65
+        _COMMAND_ID = 0
+
+    b = B()
+    assert b._GROUP_ID == 65
+    assert b._COMMAND_ID == 0
+
+    class MyGroupId(IntEnum):
+        C = 64
+        D = 65
+
+    class C(smpmsg.ReadRequest):
+        _GROUP_ID = MyGroupId.C
+        _COMMAND_ID = 0
+
+    c = C()
+    assert c._GROUP_ID == MyGroupId.C
+    assert c._COMMAND_ID == 0
+
+    class D(smpmsg.ReadRequest):
+        _GROUP_ID = MyGroupId.D
+        _COMMAND_ID = 0
+
+    d = D()
+    assert d._GROUP_ID == MyGroupId.D
+    assert d._COMMAND_ID == 0
 
 
 @pytest.mark.parametrize(
@@ -36,7 +63,7 @@ def test_custom_ReadRequest() -> None:
         smpmsg.Response,
     ],
 )
-@pytest.mark.parametrize("group_id", [GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM, 0xFFFF])
+@pytest.mark.parametrize("group_id", [USER_GROUP_ID_MIN, 0xFFFF])
 @pytest.mark.parametrize("command_id", [0, 1, 0xFF])
 def test_custom_message(cls: Type[smpmsg._MessageBase], group_id: int, command_id: int) -> None:
     """Test ReadRequest inheritance."""
@@ -77,7 +104,7 @@ def test_invalid_command_id() -> None:
     with pytest.raises(struct.error):
 
         class A(smpmsg.ReadRequest):
-            _GROUP_ID = GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM
+            _GROUP_ID = USER_GROUP_ID_MIN
             _COMMAND_ID = 0x100
 
         A()
@@ -85,7 +112,7 @@ def test_invalid_command_id() -> None:
     with pytest.raises(struct.error):
 
         class B(smpmsg.ReadRequest):
-            _GROUP_ID = GROUP_ID_THAT_IS_NOT_IN_GROUP_ID_ENUM
+            _GROUP_ID = USER_GROUP_ID_MIN
             _COMMAND_ID = -1
 
         B()

--- a/tests/user/test_intercreate.py
+++ b/tests/user/test_intercreate.py
@@ -14,7 +14,7 @@ def test_initial_ImageUploadWriteRequest() -> None:
     )
 
     assert_header = make_assert_header(
-        ic.header.GroupId.INTERCREATE,
+        ic.header.UserGroupId.INTERCREATE,
         ic.header.OP.WRITE,
         ic.header.CommandId.Intercreate.UPLOAD,
         len(r.BYTES) - ic.header.Header.SIZE,
@@ -36,7 +36,7 @@ def test_subsequent_ImageUploadWriteRequest() -> None:
     )
 
     assert_header = make_assert_header(
-        ic.header.GroupId.INTERCREATE,
+        ic.header.UserGroupId.INTERCREATE,
         ic.header.OP.WRITE,
         ic.header.CommandId.Intercreate.UPLOAD,
         len(r.BYTES) - ic.header.Header.SIZE,
@@ -55,7 +55,7 @@ def test_ImageUploadWriteResponse() -> None:
     r = ic.ImageUploadWriteResponse(header=None, sequence=0, off=105000)
 
     assert_header = make_assert_header(
-        ic.header.GroupId.INTERCREATE,
+        ic.header.UserGroupId.INTERCREATE,
         ic.header.OP.WRITE_RSP,
         ic.header.CommandId.Intercreate.UPLOAD,
         len(r.BYTES) - ic.header.Header.SIZE,


### PR DESCRIPTION
Fixes #13.  Regular GroupId IntEnum is now reserved for specified SMP groups.  Users can optionally register their custom group IDs in UserGroupId but no validation is done.

This is a breaking change for all dependencies that expect the Intercreate group ID to be in the GroupId enum.