### PR TITLE
BREAKING CHANGE: Fix/image upload write response

### DIFF
--- a/envr-default
+++ b/envr-default
@@ -8,4 +8,4 @@ PYTHON_VENV=.venv
 
 [ALIASES]
 lint=black --check . && isort --check-only . && flake8 . && mypy .
-test=(coverage erase && pytest --cov --maxfail=3 -n auto)
+test=coverage erase && pytest --cov --maxfail=3 -n auto

--- a/smp/image_management.py
+++ b/smp/image_management.py
@@ -75,20 +75,23 @@ class ImageUploadWriteRequest(message.WriteRequest):
     upgrade: bool | None = None  # allowed when off == 0
 
 
-class ImageUploadProgressWriteResponse(message.WriteResponse):
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.UPLOAD
-
-    rc: int | None = None
-    off: int | None = None
-
-
-class ImageUploadFinalWriteResponse(message.WriteResponse):
+class ImageUploadWriteResponse(message.WriteResponse):
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
     _COMMAND_ID = header.CommandId.ImageManagement.UPLOAD
 
     off: int | None = None
+    """The portion of the upload that has been completed, in 8-bit bytes.
+
+    This is the offset of the next byte to be written. If the offset is equal to
+    the length of the image, the upload is complete.
+    """
     match: bool | None = None
+    """Indicates if the uploaded data successfully matches the provided SHA256.
+
+    Only sent in the final packet if CONFIG_IMG_ENABLE_IMAGE_CHECK is enabled.
+    """
+    rc: int | None = None
+    """Unspecified field used by MCUBoot's SMP Server implementation."""
 
 
 class ImageEraseRequest(message.WriteRequest):

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import cast
 
 import cbor2
@@ -264,12 +265,21 @@ def test_ImageUploadWriteResponse(off: int | None, match: bool | None, rc: int |
     assert r.match == match
     assert r.rc == rc
 
-    cbor_dict = (
-        {}
-        | ({"off": off} if off is not None else {})
-        | ({"match": match} if match is not None else {})
-        | ({"rc": rc} if rc is not None else {})
-    )
+    if sys.version_info >= (3, 9):
+        cbor_dict = (
+            {}
+            | ({"off": off} if off is not None else {})
+            | ({"match": match} if match is not None else {})
+            | ({"rc": rc} if rc is not None else {})
+        )
+    else:
+        cbor_dict = {}
+        if off is not None:
+            cbor_dict["off"] = off
+        if match is not None:
+            cbor_dict["match"] = match
+        if rc is not None:
+            cbor_dict["rc"] = rc
 
     r = smpimg.ImageUploadWriteResponse.load(cast(smpheader.Header, r.header), cbor_dict)
     assert_header(r)

--- a/tests/test_injected_header.py
+++ b/tests/test_injected_header.py
@@ -87,7 +87,7 @@ def test_ImageUploadWriteResponse_injected_header() -> None:
         command_id=smphdr.CommandId.ImageManagement.UPLOAD,
     )
 
-    r = smpimg.ImageUploadProgressWriteResponse(
+    r = smpimg.ImageUploadWriteResponse(
         header=smphdr.Header(
             op=h.op,
             version=h.version,


### PR DESCRIPTION
Removes ImageUploadProgressWriteResponse and ImageUploadFinalWriteResponse in favor of ImageUploadWriteResponse.  The unspecified behavior of some SMP Servers that may send an "rc" field in the ImageUploadWriteResponse is handled as an optional CBOR field.

This will fix https://github.com/intercreate/smpclient/issues/31