### PR TITLE
Breaking/default to v2

### DIFF
--- a/envr.ps1
+++ b/envr.ps1
@@ -1,12 +1,25 @@
-# envr v0.5.3
+# envr v0.5.7
 # https://www.github.com/JPHutchins/envr
 # https://www.crumpledpaper.tech
 
 # MIT License
-# Copyright (c) 2022-2023 J.P. Hutchins
+# Copyright (c) 2022-2024 JP Hutchins
 # License text at the bottom of this source file
 
 # Usage: . ./envr.ps1
+
+# To "install" envr, add the alias `envr = . ./envr.ps1` to your shell profile.
+# This will allow you to run `envr` instead of `. ./envr.ps1` to activate the 
+# environment defined for the current directory,
+
+# Windows (PowerShell) "installation":
+#   Add-Content -Path $profile -Value "function envr { . ./envr.ps1 }"
+
+# bash "installation":
+#   echo "alias envr='. ./envr.ps1'" >> ~/.bashrc
+
+# zsh "installation":
+#   echo "alias envr='. ./envr.ps1'" >> ~/.zshrc
 
 # The following line is for PowerShell/bash cross compatability.
 # - The bash section shall begin with the delimiter "<#'"
@@ -270,7 +283,7 @@ _envr_set_prompt_prefix () {
         if [[ -n "${BASH:-}" ]] ; then
             PS1="\[\033[0;36m\](${_PROMPT}) ${PS1:-}"
         elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-            PS1="\033[0;36m(${_PROMPT}) ${PS1:-}"
+            PS1="%F{36}(${_PROMPT})%F{reset} ${PS1:-}"
         fi
         
         export PS1
@@ -516,7 +529,15 @@ function global:unsource ([switch]$NonDestructive) {
 
     if (Get-Variable -Name "ENVR_ROOT" -ErrorAction SilentlyContinue) {
         Remove-Variable -Name ENVR_ROOT -Scope Global -Force
-    } 
+    }
+
+    # Remove project options:
+    if (Test-Path -Path env:ENVR_ROOT) {
+        Remove-Item -Path env:ENVR_ROOT
+    }
+    if (Test-Path -Path env:ENVR_PROJECT_NAME) {
+        Remove-Item -Path env:ENVR_PROJECT_NAME
+    }
 
     # Remove variables leftover from script run
     # $_VAR_REMOVE_LIST = 
@@ -668,17 +689,17 @@ $global:_ENVR_NEW_ALIASES.GetEnumerator().ForEach({
     $global:_ALIAS_COMMAND_ARR += ,$ExecutionContext.InvokeCommand.ExpandString($val)
 
     # Hack to support aliases with parameters
-    function _ENVR_ALIAS_FN_0 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[0]) $args" }
-    function _ENVR_ALIAS_FN_1 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[1]) $args" }
-    function _ENVR_ALIAS_FN_2 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[2]) $args" }
-    function _ENVR_ALIAS_FN_3 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[3]) $args" }
-    function _ENVR_ALIAS_FN_4 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[4]) $args" }
-    function _ENVR_ALIAS_FN_5 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[5]) $args" }
-    function _ENVR_ALIAS_FN_6 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[6]) $args" }
-    function _ENVR_ALIAS_FN_7 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[7]) $args" }
-    function _ENVR_ALIAS_FN_8 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[8]) $args" }
-    function _ENVR_ALIAS_FN_9 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[9]) $args" }
-    Set-Alias -Name $key -Value "_ENVR_ALIAS_FN_$global:_ALIAS_FN_INDEX"
+    function script:_ENVR_ALIAS_FN_0 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[0]) $args" }
+    function script:_ENVR_ALIAS_FN_1 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[1]) $args" }
+    function script:_ENVR_ALIAS_FN_2 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[2]) $args" }
+    function script:_ENVR_ALIAS_FN_3 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[3]) $args" }
+    function script:_ENVR_ALIAS_FN_4 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[4]) $args" }
+    function script:_ENVR_ALIAS_FN_5 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[5]) $args" }
+    function script:_ENVR_ALIAS_FN_6 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[6]) $args" }
+    function script:_ENVR_ALIAS_FN_7 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[7]) $args" }
+    function script:_ENVR_ALIAS_FN_8 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[8]) $args" }
+    function script:_ENVR_ALIAS_FN_9 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[9]) $args" }
+    Set-Alias -Name $key -Value "_ENVR_ALIAS_FN_$global:_ALIAS_FN_INDEX" -Scope script
     $global:_ALIAS_FN_INDEX += 1
 })
 
@@ -746,7 +767,7 @@ POWERSHELL_SECTION
 # License text continued
 
 # MIT License
-# Copyright (c) 2022 J.P. Hutchins
+# Copyright (c) 2022-2024 JP Hutchins
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/smp/error.py
+++ b/smp/error.py
@@ -63,8 +63,8 @@ class MGMT_ERR(IntEnum):
     """User errors defined from 256 onwards"""
 
 
-class ErrorV0(message.Response):
-    RESPONSE_TYPE = message.ResponseType.ERROR_V0
+class ErrorV1(message.Response):
+    RESPONSE_TYPE = message.ResponseType.ERROR_V1
 
     rc: MGMT_ERR
     """Error code."""
@@ -80,7 +80,7 @@ class Err(BaseModel, Generic[T]):
     rc: T
 
 
-class ErrorV1(message.Response, Generic[T]):
-    RESPONSE_TYPE = message.ResponseType.ERROR_V1
+class ErrorV2(message.Response, Generic[T]):
+    RESPONSE_TYPE = message.ResponseType.ERROR_V2
 
     err: Err[T]

--- a/smp/file_management.py
+++ b/smp/file_management.py
@@ -165,9 +165,9 @@ class FS_MGMT_ERR(IntEnum):
     """The operation cannot be performed because the file is empty with no contents. """
 
 
-class FileSystemManagementErrorV0(error.ErrorV0):
+class FileSystemManagementErrorV1(error.ErrorV1):
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
 
 
-class FileSystemManagementErrorV1(error.ErrorV1[FS_MGMT_ERR]):
+class FileSystemManagementErrorV2(error.ErrorV2[FS_MGMT_ERR]):
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT

--- a/smp/header.py
+++ b/smp/header.py
@@ -93,8 +93,8 @@ class _OP_BIT:
 
 @unique
 class Version(IntEnum):
-    V0 = 0
-    V1 = 1
+    V1 = 0
+    V2 = 1
 
 
 class _VERSION_BIT:

--- a/smp/header.py
+++ b/smp/header.py
@@ -174,6 +174,7 @@ class Header:
     def __post_init__(self) -> None:
         Header._validate_command_id(self.group_id, self.command_id)
 
+        self._bytes: bytes
         object.__setattr__(
             self,
             '_bytes',
@@ -188,11 +189,11 @@ class Header:
         )
 
     def __bytes__(self) -> bytes:
-        return self._bytes  # type: ignore
+        return self._bytes
 
     @property
     def BYTES(self) -> bytes:
-        return self._bytes  # type: ignore
+        return self._bytes
 
     @staticmethod
     def loads(header: bytes) -> 'Header':

--- a/smp/image_management.py
+++ b/smp/image_management.py
@@ -212,9 +212,9 @@ class IMG_MGMT_ERR(IntEnum):
     """Setting test to active slot is not allowed"""
 
 
-class ImageManagementErrorV0(error.ErrorV0):
+class ImageManagementErrorV1(error.ErrorV1):
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
 
 
-class ImageManagementErrorV1(error.ErrorV1[IMG_MGMT_ERR]):
+class ImageManagementErrorV2(error.ErrorV2[IMG_MGMT_ERR]):
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT

--- a/smp/message.py
+++ b/smp/message.py
@@ -38,7 +38,7 @@ class _MessageBase(ABC, BaseModel):
 
     # This is is a dummy header that will be replaced in model_post_init
     header: smpheader.Header = None  # type: ignore
-    version: smpheader.Version = smpheader.Version.V1
+    version: smpheader.Version = smpheader.Version.V2
     sequence: int = None  # type: ignore
 
     def __bytes__(self) -> bytes:
@@ -120,11 +120,11 @@ class Request(_MessageBase, ABC):
 
 @unique
 class ResponseType(IntEnum):
-    """An SMP `Response` to an SMP `Request` must be `SUCCESS`, `ERROR_V0`, or `ERROR_V1`."""
+    """An SMP `Response` to an SMP `Request` must be `SUCCESS`, `ERROR_V1`, or `ERROR_V2`."""
 
     SUCCESS = 0
-    ERROR_V0 = 1
-    ERROR_V1 = 2
+    ERROR_V1 = 1
+    ERROR_V2 = 2
 
 
 class Response(_MessageBase, ABC):

--- a/smp/message.py
+++ b/smp/message.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import logging
 from abc import ABC
 from enum import IntEnum, unique
 from typing import ClassVar, Type, TypeVar, cast
@@ -17,13 +18,13 @@ T = TypeVar("T", bound='_MessageBase')
 
 
 _counter = itertools.count()
+logger = logging.getLogger(__name__)
 
 
 class _MessageBase(ABC, BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     _OP: ClassVar[smpheader.OP]
-    _VERSION: ClassVar[smpheader.Version] = smpheader.Version.V0
     _FLAGS: ClassVar[smpheader.Flag] = smpheader.Flag(0)
     _GROUP_ID: ClassVar[smpheader.GroupId | smpheader.UserGroupId | smpheader.AnyGroupId]
     _COMMAND_ID: ClassVar[
@@ -35,14 +36,17 @@ class _MessageBase(ABC, BaseModel):
         | smpheader.CommandId.FileManagement
     ]
 
-    header: smpheader.Header | None = None
+    # This is is a dummy header that will be replaced in model_post_init
+    header: smpheader.Header = None  # type: ignore
+    version: smpheader.Version = smpheader.Version.V1
+    sequence: int = None  # type: ignore
 
     def __bytes__(self) -> bytes:
-        return self._bytes  # type: ignore
+        return self._bytes
 
     @property
     def BYTES(self) -> bytes:
-        return self._bytes  # type: ignore
+        return self._bytes
 
     @classmethod
     def loads(cls: Type[T], data: bytes) -> T:
@@ -68,31 +72,50 @@ class _MessageBase(ABC, BaseModel):
             )
         return cls(header=header, **data)
 
-
-class Request(_MessageBase, ABC):
     def model_post_init(self, _: None) -> None:
         data_bytes = cbor2.dumps(
-            self.model_dump(exclude_unset=True, exclude={'header'}, exclude_none=True)
+            self.model_dump(
+                exclude_unset=True, exclude={'header', 'version', 'sequence'}, exclude_none=True
+            )
         )
-        if self.header is None:
+        self._bytes: bytes
+        if self.header is None:  # create the header
             object.__setattr__(
                 self,
                 'header',
                 smpheader.Header(
                     op=self._OP,
-                    version=self._VERSION,
+                    version=self.version,
                     flags=smpheader.Flag(self._FLAGS),
                     length=len(data_bytes),
                     group_id=self._GROUP_ID,
-                    sequence=next(_counter) % 0xFF,
+                    sequence=next(_counter) % 0xFF if self.sequence is None else self.sequence,
                     command_id=self._COMMAND_ID,
                 ),
             )
-        elif self.header.length != len(data_bytes):
-            raise SMPMalformed(
-                f"header.length {self.header.length} != len(data_bytes) {len(data_bytes)}"
-            )
-        self._bytes = cast(smpheader.Header, self.header).BYTES + data_bytes
+            object.__setattr__(self, 'sequence', self.header.sequence)
+        else:  # validate the header and update version & sequence
+            if self.header.length != len(data_bytes):
+                raise SMPMalformed(
+                    f"header.length {self.header.length} != len(data_bytes) {len(data_bytes)}"
+                )
+            if self.sequence is not None:  # pragma: no cover
+                raise ValueError(
+                    f"{self.sequence=} {self.header.sequence=} "
+                    "Do not use the sequence attribute when the header is provided."
+                )
+            object.__setattr__(self, 'sequence', self.header.sequence)
+            if self.version != self.header.version:
+                logger.warning(
+                    f"Overriding {self.version=} with {self.header.version=} "
+                    "from the provided header."
+                )
+            object.__setattr__(self, 'version', self.header.version)
+        self._bytes = self.header.BYTES + data_bytes
+
+
+class Request(_MessageBase, ABC):
+    ...
 
 
 @unique
@@ -105,29 +128,7 @@ class ResponseType(IntEnum):
 
 
 class Response(_MessageBase, ABC):
-    sequence: int = 0
-
     RESPONSE_TYPE: ClassVar[ResponseType]
-
-    def model_post_init(self, _: None) -> None:
-        data_bytes = cbor2.dumps(
-            self.model_dump(exclude_unset=True, exclude={'header', 'sequence'}, exclude_none=True)
-        )
-        if self.header is None:
-            object.__setattr__(
-                self,
-                'header',
-                smpheader.Header(
-                    op=self._OP,
-                    version=self._VERSION,
-                    flags=smpheader.Flag(self._FLAGS),
-                    length=len(data_bytes),
-                    group_id=self._GROUP_ID,
-                    sequence=self.sequence,
-                    command_id=self._COMMAND_ID,
-                ),
-            )
-        self._bytes = cast(smpheader.Header, self.header).BYTES + data_bytes
 
 
 class ReadRequest(Request, ABC):

--- a/smp/os_management.py
+++ b/smp/os_management.py
@@ -243,9 +243,9 @@ class OS_MGMT_RET_RC(IntEnum):
     """RTC command failed."""
 
 
-class OSManagementErrorV0(error.ErrorV0):
+class OSManagementErrorV1(error.ErrorV1):
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
 
 
-class OSManagementErrorV1(error.ErrorV1[OS_MGMT_RET_RC]):
+class OSManagementErrorV2(error.ErrorV2[OS_MGMT_RET_RC]):
     _GROUP_ID = header.GroupId.OS_MANAGEMENT

--- a/smp/shell_management.py
+++ b/smp/shell_management.py
@@ -34,9 +34,9 @@ class SHELL_MGMT_RET_RC(IntEnum):
     """The provided format value is not valid."""
 
 
-class ShellManagementErrorV0(error.ErrorV0):
+class ShellManagementErrorV1(error.ErrorV1):
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
 
 
-class ShellManagementErrorV1(error.ErrorV1[SHELL_MGMT_RET_RC]):
+class ShellManagementErrorV2(error.ErrorV2[SHELL_MGMT_RET_RC]):
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT

--- a/smp/user/intercreate.py
+++ b/smp/user/intercreate.py
@@ -44,9 +44,9 @@ class IC_MGMT_ERR(IntEnum):
     """No image matched the image provided."""
 
 
-class ErrorV0(error.ErrorV0):
+class ErrorV1(error.ErrorV1):
     _GROUP_ID = header.UserGroupId.INTERCREATE
 
 
-class ErrorV1(error.ErrorV1[IC_MGMT_ERR]):
+class ErrorV2(error.ErrorV2[IC_MGMT_ERR]):
     _GROUP_ID = header.UserGroupId.INTERCREATE

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ def make_assert_header(
     ) -> None:
         h = r.header
         assert op == h.op
-        assert smpheader.Version.V1 == h.version
+        assert smpheader.Version.V2 == h.version
         assert 0 == h.flags
         if length is not None:
             assert length == h.length

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, cast
+from typing import Callable
 
 from smp import header as smpheader
 from smp.message import _MessageBase
@@ -17,9 +17,9 @@ def make_assert_header(
     def f(
         r: _MessageBase,
     ) -> None:
-        h = cast(smpheader.Header, r.header)
+        h = r.header
         assert op == h.op
-        assert smpheader.Version.V0 == h.version
+        assert smpheader.Version.V1 == h.version
         assert 0 == h.flags
         if length is not None:
             assert length == h.length

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -10,7 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from smp import header as smpheader
-from smp.error import MGMT_ERR, ErrorV0, ErrorV1
+from smp.error import MGMT_ERR, ErrorV1, ErrorV2
 
 
 class FAKE_ERR(IntEnum):
@@ -18,18 +18,18 @@ class FAKE_ERR(IntEnum):
     ERR = 1
 
 
-class FakeErrorV0(ErrorV0):
+class FakeErrorV1(ErrorV1):
     _GROUP_ID = smpheader.GroupId.IMAGE_MANAGEMENT
 
 
-class FakeErrorV1(ErrorV1[FAKE_ERR]):
+class FakeErrorV2(ErrorV2[FAKE_ERR]):
     _GROUP_ID = smpheader.GroupId.IMAGE_MANAGEMENT
 
 
 make_header = partial(
     smpheader.Header,
     op=smpheader.OP.READ,
-    version=smpheader.Version.V0,
+    version=smpheader.Version.V1,
     flags=smpheader.Flag(0),
     group_id=smpheader.GroupId.IMAGE_MANAGEMENT,
     sequence=0,
@@ -39,16 +39,16 @@ make_header = partial(
 
 @pytest.mark.parametrize("rc", [e.value for e in MGMT_ERR])
 @pytest.mark.parametrize("rsn", ["something", None])
-def test_ErrorV0(rc: MGMT_ERR, rsn: str | None) -> None:
+def test_ErrorV1(rc: MGMT_ERR, rsn: str | None) -> None:
     d = cbor2.dumps({"rc": rc} if rsn is None else {"rc": rc, "rsn": rsn})  # type: ignore
     h = make_header(length=len(d))
 
     if rc > max(MGMT_ERR):
         with pytest.raises(ValidationError):
-            FakeErrorV0.loads(h.BYTES + d)
+            FakeErrorV1.loads(h.BYTES + d)
         return
 
-    e = FakeErrorV0.loads(h.BYTES + d)
+    e = FakeErrorV1.loads(h.BYTES + d)
     assert MGMT_ERR is type(e.rc)
     assert rc == e.rc
     if rsn is not None:
@@ -57,26 +57,26 @@ def test_ErrorV0(rc: MGMT_ERR, rsn: str | None) -> None:
         assert None is e.rsn
 
     with pytest.raises(ValidationError):
-        FakeErrorV1.loads(h.BYTES + d)
+        FakeErrorV2.loads(h.BYTES + d)
 
 
 @pytest.mark.parametrize("rc", [FAKE_ERR.OK, FAKE_ERR.ERR, 2])
 @pytest.mark.parametrize(
     "group", [smpheader.GroupId.OS_MANAGEMENT, smpheader.GroupId.IMAGE_MANAGEMENT]
 )
-def test_ErrorV1(rc: FAKE_ERR, group: smpheader.GroupId) -> None:
+def test_ErrorV2(rc: FAKE_ERR, group: smpheader.GroupId) -> None:
     d = cbor2.dumps({"err": {"rc": rc, "group": group}})
     h = make_header(length=len(d))
 
     if rc > max(FAKE_ERR):
         with pytest.raises(ValidationError):
-            FakeErrorV1.loads(h.BYTES + d)
+            FakeErrorV2.loads(h.BYTES + d)
         return
 
-    e = FakeErrorV1.loads(h.BYTES + d)
+    e = FakeErrorV2.loads(h.BYTES + d)
     assert FAKE_ERR is type(e.err.rc)
     assert rc == e.err.rc
     assert group == e.err.group
 
     with pytest.raises(ValidationError):
-        FakeErrorV0.loads(h.BYTES + d)
+        FakeErrorV1.loads(h.BYTES + d)

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -28,10 +28,10 @@ def test_header_serialization(
         Header._MAP_GROUP_ID_TO_COMMAND_ID_ENUM[group_id]
     ):
         with pytest.raises((KeyError, ValueError)):
-            h = Header(op, version, flags, length, group_id, sequence, command_id)  # type: ignore
+            h = Header(op, version, flags, length, group_id, sequence, command_id)
         return
 
-    h = Header(op, version, flags, length, group_id, sequence, command_id)  # type: ignore
+    h = Header(op, version, flags, length, group_id, sequence, command_id)
 
     # test the abstract data type
     assert op == h.op
@@ -78,11 +78,11 @@ def test_header_deserialization(
         Header._MAP_GROUP_ID_TO_COMMAND_ID_ENUM[group_id]
     ):
         with pytest.raises((KeyError, ValueError)):
-            _h = Header(op, version, flags, length, group_id, sequence, command_id)  # type: ignore
+            _h = Header(op, version, flags, length, group_id, sequence, command_id)
             h = Header.loads(_h.BYTES)
         return
 
-    _h = Header(op, version, flags, length, group_id, sequence, command_id)  # type: ignore
+    _h = Header(op, version, flags, length, group_id, sequence, command_id)
     h = Header.loads(_h.BYTES)
 
     # test the abstract data type

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -8,7 +8,7 @@ from smp.header import OP, Flag, GroupId, Header, Version
 
 
 @pytest.mark.parametrize("op", [OP.READ, OP.READ_RSP, OP.WRITE, OP.WRITE_RSP])
-@pytest.mark.parametrize("version", [Version.V0, Version.V1])
+@pytest.mark.parametrize("version", [Version.V1, Version.V2])
 @pytest.mark.parametrize("flags", [Flag(0b0), Flag(0b1), Flag(0xFF)])
 @pytest.mark.parametrize("length", [0, 1, 0xFFFF])
 @pytest.mark.parametrize("group_id", [0, 1, 0xFFFF])
@@ -58,7 +58,7 @@ def test_header_serialization(
 
 
 @pytest.mark.parametrize("op", [OP.READ, OP.READ_RSP, OP.WRITE, OP.WRITE_RSP])
-@pytest.mark.parametrize("version", [Version.V0, Version.V1])
+@pytest.mark.parametrize("version", [Version.V1, Version.V2])
 @pytest.mark.parametrize("flags", [Flag(0b0), Flag(0b1), Flag(0xFF)])
 @pytest.mark.parametrize("length", [0, 1, 0xFFFF])
 @pytest.mark.parametrize("group_id", [0, 1, 0xFFFF])

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -29,7 +29,7 @@ def test_ImageStatesReadRequest() -> None:
     assert_header(r)
     assert smpheader.Header.SIZE + 1 == len(r.BYTES)
 
-    r = smpimg.ImageStatesReadRequest.load(cast(smpheader.Header, r.header), {})
+    r = smpimg.ImageStatesReadRequest.load(r.header, {})
     assert_header(r)
     assert smpheader.Header.SIZE + 1 == len(r.BYTES)
 
@@ -119,7 +119,7 @@ def test_ImageStatesReadResponse(
     assert_response(r2)
 
     r3 = smpimg.ImageStatesReadResponse.load(
-        cast(smpheader.Header, r1.header), r1.model_dump(exclude={'header'})
+        r1.header, r1.model_dump(exclude={'header', 'sequence'})
     )
     assert_header(r3)
     assert_response(r3)
@@ -141,7 +141,7 @@ def test_ImageEraseRequest() -> None:
     assert_header(r)
     assert smpheader.Header.SIZE + 1 == len(r.BYTES)
 
-    r = smpimg.ImageEraseRequest.load(cast(smpheader.Header, r.header), {})
+    r = smpimg.ImageEraseRequest.load(r.header, {})
     assert_header(r)
     assert smpheader.Header.SIZE + 1 == len(r.BYTES)
 
@@ -177,7 +177,7 @@ def test_ImageEraseResponse() -> None:
     assert_header(r)
     assert smpheader.Header.SIZE + 1 == len(r.BYTES)
 
-    r = smpimg.ImageEraseResponse.load(cast(smpheader.Header, r.header), {})
+    r = smpimg.ImageEraseResponse.load(r.header, {})
     assert_header(r)
     assert smpheader.Header.SIZE + 1 == len(r.BYTES)
 
@@ -281,7 +281,7 @@ def test_ImageUploadWriteResponse(off: int | None, match: bool | None, rc: int |
         if rc is not None:
             cbor_dict["rc"] = rc
 
-    r = smpimg.ImageUploadWriteResponse.load(cast(smpheader.Header, r.header), cbor_dict)
+    r = smpimg.ImageUploadWriteResponse.load(r.header, cbor_dict)
     assert_header(r)
     assert r.off == off
     assert r.match == match

--- a/tests/test_injected_header.py
+++ b/tests/test_injected_header.py
@@ -1,6 +1,5 @@
 """Test the case where the user forms the header separately."""
 
-from typing import cast
 
 import pytest
 
@@ -38,7 +37,7 @@ def test_ImageUploadWriteRequest_injected_header() -> None:
         len=50,
     )
 
-    assert cast(smphdr.Header, r.header).length == 76
+    assert r.header.length == 76
     assert len(r.BYTES) == 76 + smphdr.Header.SIZE
 
     with pytest.raises(SMPMalformed):
@@ -101,5 +100,5 @@ def test_ImageUploadWriteResponse_injected_header() -> None:
         off=0,
     )
 
-    assert cast(smphdr.Header, r.header).length == 10
+    assert r.header.length == 10
     assert len(r.BYTES) == 10 + smphdr.Header.SIZE

--- a/tests/test_injected_header.py
+++ b/tests/test_injected_header.py
@@ -11,7 +11,7 @@ from smp.exceptions import SMPMalformed
 def test_ImageUploadWriteRequest_injected_header() -> None:
     h = smphdr.Header(
         op=smphdr.OP.WRITE,
-        version=smphdr.Version.V0,
+        version=smphdr.Version.V1,
         flags=smphdr.Flag(0),
         length=0,
         group_id=smphdr.GroupId.IMAGE_MANAGEMENT,
@@ -78,7 +78,7 @@ def test_ImageUploadWriteRequest_injected_header() -> None:
 def test_ImageUploadWriteResponse_injected_header() -> None:
     h = smphdr.Header(
         op=smphdr.OP.WRITE_RSP,
-        version=smphdr.Version.V0,
+        version=smphdr.Version.V1,
         flags=smphdr.Flag(0),
         length=0,
         group_id=smphdr.GroupId.IMAGE_MANAGEMENT,

--- a/tests/test_os_management.py
+++ b/tests/test_os_management.py
@@ -216,5 +216,6 @@ def test_BootloaderInformationReadResponse() -> None:
     )
 
     assert r.bootloader == "MCUboot"
-    assert r.response["mode"] == smpos.MCUbootMode.SWAP_WITHOUT_SCRATCH  # type: ignore
-    assert r.response["no-downgrade"] is True  # type: ignore
+    assert type(r.response) is dict
+    assert r.response["mode"] == smpos.MCUbootMode.SWAP_WITHOUT_SCRATCH
+    assert r.response["no-downgrade"] is True

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -24,7 +24,7 @@ def _assert_header(frame: bytes) -> None:
     # deserialize the header
     h = header.Header.loads(frame[: header.Header.SIZE])
     assert header.OP.WRITE == h.op
-    assert header.Version.V1 == h.version
+    assert header.Version.V2 == h.version
     assert 0 == h.flags
     assert h.length != 0  # TODO: unsure how to check length more specifically
     assert header.GroupId.IMAGE_MANAGEMENT == h.group_id

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -24,7 +24,7 @@ def _assert_header(frame: bytes) -> None:
     # deserialize the header
     h = header.Header.loads(frame[: header.Header.SIZE])
     assert header.OP.WRITE == h.op
-    assert header.Version.V0 == h.version
+    assert header.Version.V1 == h.version
     assert 0 == h.flags
     assert h.length != 0  # TODO: unsure how to check length more specifically
     assert header.GroupId.IMAGE_MANAGEMENT == h.group_id

--- a/tests/user/test_intercreate.py
+++ b/tests/user/test_intercreate.py
@@ -52,7 +52,7 @@ def test_subsequent_ImageUploadWriteRequest() -> None:
 
 
 def test_ImageUploadWriteResponse() -> None:
-    r = ic.ImageUploadWriteResponse(header=None, sequence=0, off=105000)
+    r = ic.ImageUploadWriteResponse(sequence=0, off=105000)
 
     assert_header = make_assert_header(
         ic.header.UserGroupId.INTERCREATE,


### PR DESCRIPTION
This corrects the SMP version names from V0/1 -> V1/2 and sets the default version to V2.  Every constructed request/response can now take a sequence and version argument, optionally, which will be used to construct the header.

Fixes #6
Fixes #7