### PR TITLE
error: allow user and external group ids

### DIFF
--- a/smp/enumeration_management.py
+++ b/smp/enumeration_management.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import Tuple, Union
+from typing import Tuple
 
-from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Annotated
+from pydantic import BaseModel, ConfigDict
 
 import smp.error as smperr
 import smp.header as smphdr
 import smp.message as smpmsg
-
-GroupIdField = Annotated[
-    Union[smphdr.GroupId, smphdr.UserGroupId, int], Field(union_mode="left_to_right")
-]
 
 
 class GroupCountRequest(smpmsg.ReadRequest):
@@ -51,7 +46,7 @@ class ListOfGroupsResponse(smpmsg.ReadResponse):
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.LIST_OF_GROUPS
 
-    groups: Tuple[GroupIdField, ...]
+    groups: Tuple[smphdr.GroupIdField, ...]
     """Contains a list of the supported SMP group IDs on the device."""
 
 
@@ -77,7 +72,7 @@ class GroupIdResponse(smpmsg.ReadResponse):
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_ID
 
-    group: GroupIdField
+    group: smphdr.GroupIdField
     """The Group ID at the requested index."""
     end: bool | None = None
     """Will be set to true if the listed group is the final supported group on
@@ -102,7 +97,7 @@ class GroupDetailsRequest(smpmsg.ReadRequest):
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_DETAILS
 
-    groups: Tuple[GroupIdField, ...] | None = None
+    groups: Tuple[smphdr.GroupIdField, ...] | None = None
     """Contains a list of the SMP group IDs to fetch details on.
 
     If omitted, details on all supported groups will be returned.
@@ -114,7 +109,7 @@ class GroupDetails(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    id: GroupIdField
+    id: smphdr.GroupIdField
     """The group ID of the SMP command group."""
     name: str | None = None
     """The name of the SMP command group."""

--- a/smp/error.py
+++ b/smp/error.py
@@ -8,7 +8,7 @@ from typing import Generic, TypeVar
 from pydantic import BaseModel, ConfigDict
 
 from smp import message
-from smp.header import GroupId
+from smp.header import GroupIdField
 
 T = TypeVar("T", bound=IntEnum)
 
@@ -80,7 +80,7 @@ class Err(BaseModel, Generic[T]):
 
     model_config = ConfigDict(extra="forbid", frozen=True, arbitrary_types_allowed=True)
 
-    group: GroupId
+    group: GroupIdField
     rc: T
 
 

--- a/smp/header.py
+++ b/smp/header.py
@@ -103,9 +103,6 @@ class UserGroupId(IntEnum):
 GroupIdField = Annotated[Union[GroupId, UserGroupId, int], Field(union_mode="left_to_right")]
 
 
-AnyGroupId: TypeAlias = Union[IntEnum, int]
-
-
 @unique
 class OP(IntEnum):
     READ = 0
@@ -141,7 +138,7 @@ class Header:
     version: Version
     flags: Flag
     length: int
-    group_id: Union[AnyGroupId, GroupId, UserGroupId]
+    group_id: GroupIdField
     sequence: int
     command_id: Union[
         AnyCommandId,

--- a/smp/header.py
+++ b/smp/header.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from enum import IntEnum, IntFlag, unique
 from typing import ClassVar, Dict, Type, Union
 
-from typing_extensions import TypeAlias
+from pydantic import Field
+from typing_extensions import Annotated, TypeAlias
 
 
 class CommandId:
@@ -97,6 +98,9 @@ class UserGroupId(IntEnum):
     It is optional to register them here."""
 
     INTERCREATE = 64
+
+
+GroupIdField = Annotated[Union[GroupId, UserGroupId, int], Field(union_mode="left_to_right")]
 
 
 AnyGroupId: TypeAlias = Union[IntEnum, int]

--- a/smp/message.py
+++ b/smp/message.py
@@ -28,7 +28,7 @@ class _MessageBase(ABC, BaseModel):
 
     _OP: ClassVar[smpheader.OP]
     _FLAGS: ClassVar[smpheader.Flag] = smpheader.Flag(0)
-    _GROUP_ID: ClassVar[smpheader.GroupId | smpheader.UserGroupId | smpheader.AnyGroupId]
+    _GROUP_ID: ClassVar[smpheader.GroupIdField]
     _COMMAND_ID: ClassVar[
         smpheader.AnyCommandId
         | smpheader.CommandId.ImageManagement


### PR DESCRIPTION
The V2 Error group field only accepted header.GroupId, which would lead to validation errors when smpclient received v2 error responses from SMP groups beyond the standard set. This change allows creating ErrorV2 instances for both User Groups defined in the tree (i.e. Intercreate) as well as for User Groups defined outside of the tree.

Let me know if there's a more preferred way to solve this problem!