### PR TITLE
breaking: header and smp_data in Frame (related to #45)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   lint:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/smp/__init__.py
+++ b/smp/__init__.py
@@ -34,15 +34,14 @@ load a `smp.os_management.EchoWriteResponse`:
 from smp.os_management import EchoWriteResponse
 
 data = bytes.fromhex("0b00000700008c00a1617263486921")  # data from the transport
-response = EchoWriteResponse.loads(data)
-print(response)
+header, response = EchoWriteResponse.loads(data)
+print(header, response)
 ```
 
 Prints the deserialized SMP message representation:
 ```
-header=Header(op=<OP.WRITE_RSP: 3>, version=<Version.V2: 1>, flags=<Flag: 0>,
-length=7, group_id=0, sequence=140, command_id=0) version=<Version.V2: 1>
-sequence=140 smp_data=b'\\x0b\\x00\\x00\\x07\\x00\\x00\\x8c\\x00\\xa1arcHi!' r='Hi!'
+Header(op=<OP.WRITE_RSP: 3>, version=<Version.V2: 1>, flags=<Flag.UNUSED: 0>,
+length=7, group_id=0, sequence=140, command_id=0) r='Hi!'
 ```
 Generally, the `header` can be ignored and the message-specific attributes are
 what you are interested in.
@@ -55,14 +54,18 @@ mypy linting and by Pydantic at runtime.
 
 ## Serialization
 
-There are a few optional arguments that are common to all SMP messages when they
-are created.
+An smp.message.Frame consists of:
+-   `header` the SMP header.
+-   `smp_data` the SMP data - the specific message.
 
--   `header` is the SMP header.  Typically this can be left as `None` and will be
-    so that the header is created automatically.
+Typically, the Frame is created by calling the `to_frame()` method on the
+SMPData. A few optional header params can be passed to `to_frame()`:
 -   `version` is the SMP version.  This defaults to `smp.header.Version.V2`.
+-   `flags` defaults to 0 (no flags set).
 -   `sequence` is the sequence number of the message.  If not provided, it will
     be automatically generated using an incrementing counter.
+
+The Frame is serialized using `bytes(my_frame)`.
 
 Take a look at `smp.message` for more information on the base classes.
 
@@ -71,8 +74,8 @@ Take a look at `smp.message` for more information on the base classes.
 If you are writing an SMP client, then you already know the type of the
 incoming message because it must be a Response to your Request, or an
 `smp.error.ErrorV1` or `smp.error.ErrorV2`.  You can use the
-`smp.message._MessageBase.loads()` method that is common to all SMP
-messages to deserialize and validate the message.
+`smp.message.SMPData.loads()` method that is common to all SMP
+messages to deserialize and validate the message to a Frame.
 
 If you are writing an SMP server, then Python and SMP are odd choices!  Yet, you
 can narrow the type by first loading the header with `smp.header.Header.loads()`.

--- a/tests/binary_regressions/test_binary_lock.py
+++ b/tests/binary_regressions/test_binary_lock.py
@@ -25,7 +25,7 @@ for file in list(Path("tests", "binary_regressions", "records").rglob("*.json"))
         records.extend(map(lambda x: Record(**json.loads(x)), f.readlines()))
 
 
-def import_class(full_class_path: str) -> smpmsg._MessageBase:
+def import_class(full_class_path: str) -> smpmsg.SMPData:
     module_path, class_name = full_class_path.rsplit('.', 1)
     return getattr(importlib.import_module(module_path), class_name)
 
@@ -70,7 +70,7 @@ def test_binary_lock(record: Record) -> None:
         record.kwargs["output"] = bytes.fromhex(record.kwargs["output"])
 
     # Test serialization match
-    serialized_message = cls(version=record.version, sequence=record.sequence, **record.kwargs)  # type: ignore # noqa
+    serialized_message = cls(**record.kwargs).to_frame(version=record.version, sequence=record.sequence)  # type: ignore # noqa
     assert bytes(serialized_message) == bytes.fromhex(record.bytes)
 
     # Test deserialization match
@@ -79,5 +79,5 @@ def test_binary_lock(record: Record) -> None:
     assert serialized_message == deserialized_message
 
     for k, v in record.kwargs.items():
-        actual_value: Any = getattr(deserialized_message, k)
+        actual_value: Any = getattr(deserialized_message.smp_data, k)
         compare_values(v, actual_value)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,25 +1,28 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable, Dict, Optional, Protocol, Type
 
-from smp import header as smpheader
-from smp.message import _MessageBase
+import cbor2
+from pydantic import BaseModel
+
+import smp.header as smphdr
+import smp.message as smpmsg
 
 
 def make_assert_header(
-    group_id: smpheader.GroupId | smpheader.UserGroupId,
-    op: smpheader.OP,
-    command_id: smpheader.AnyCommandId,
+    group_id: smphdr.GroupId | smphdr.UserGroupId,
+    op: smphdr.OP,
+    command_id: smphdr.AnyCommandId,
     length: int | None,
-) -> Callable[[_MessageBase], None]:
+) -> Callable[[smpmsg.Frame], None]:
     """Return an `assert_header` function."""
 
     def f(
-        r: _MessageBase,
+        f: smpmsg.Frame,
     ) -> None:
-        h = r.header
+        h = f.header
         assert op == h.op
-        assert smpheader.Version.V2 == h.version
+        assert smphdr.Version.V2 == h.version
         assert 0 == h.flags
         if length is not None:
             assert length == h.length
@@ -29,6 +32,74 @@ def make_assert_header(
         assert 0 <= h.sequence <= 0xFF
         assert command_id == h.command_id
 
-        assert r.BYTES == bytes(r)
-
     return f
+
+
+def _do_test(
+    msg: Type[smpmsg.T],
+    op: smphdr.OP,
+    command_id: Any,
+    data: Dict[str, Any],
+    nested_model: Type[BaseModel] | None = None,
+    group_id: smphdr.GroupId = None,  # type: ignore[assignment]
+) -> smpmsg.T:
+    cbor = cbor2.dumps(data, canonical=True)
+    assert_header = make_assert_header(group_id, op, command_id, len(cbor))
+
+    def _assert_common(r: smpmsg.SMPData) -> None:
+        for k, v in data.items():
+            actual = getattr(r, k)
+            if type(v) is tuple and nested_model is not None:
+                for v2, actual2 in zip(v, actual):
+                    assert v2 == nested_model(**v2).model_dump()
+            elif isinstance(v, dict) and nested_model is not None and isinstance(actual, dict):
+                for subk, subv in v.items():
+                    assert subv == actual[subk].model_dump()
+            else:
+                assert v == actual
+        assert cbor == bytes(r)
+
+    r = msg(**data)
+
+    _assert_common(r)  # serialize
+    f = msg.loads(bytes(r.to_frame()))
+    assert_header(f)
+    _assert_common(f.smp_data)  # deserialize
+
+    return r
+
+
+class DoTestProtocol(Protocol):
+    def __call__(
+        self,
+        msg: Type[smpmsg.T],
+        op: smphdr.OP,
+        command_id: Any,
+        data: Dict[str, Any],
+        nested_model: Optional[Type[BaseModel]] = ...,
+    ) -> smpmsg.T:
+        ...
+
+
+def make_do_test(
+    group_id: smphdr.GroupId,
+) -> DoTestProtocol:
+    """Return a `_do_test` function with a fixed `group_id`."""
+
+    def do_test(
+        msg: Type[smpmsg.T],
+        op: smphdr.OP,
+        command_id: Any,
+        data: Dict[str, Any],
+        nested_model: Optional[Type[BaseModel]] = None,
+    ) -> smpmsg.T:
+        return _do_test(
+            msg,
+            op,
+            command_id,
+            data,
+            nested_model=nested_model,
+            group_id=group_id,
+        )
+
+    return do_test

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -48,7 +48,7 @@ def test_ErrorV1(rc: MGMT_ERR, rsn: str | None) -> None:
             FakeErrorV1.loads(h.BYTES + d)
         return
 
-    e = FakeErrorV1.loads(h.BYTES + d)
+    _, e = FakeErrorV1.loads(h.BYTES + d)
     assert MGMT_ERR is type(e.rc)
     assert rc == e.rc
     if rsn is not None:
@@ -73,7 +73,7 @@ def test_ErrorV2(rc: FAKE_ERR, group: smpheader.GroupId) -> None:
             FakeErrorV2.loads(h.BYTES + d)
         return
 
-    e = FakeErrorV2.loads(h.BYTES + d)
+    _, e = FakeErrorV2.loads(h.BYTES + d)
     assert FAKE_ERR is type(e.err.rc)
     assert rc == e.err.rc
     assert group == e.err.group

--- a/tests/test_file_management.py
+++ b/tests/test_file_management.py
@@ -2,49 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar
-
-import cbor2
-from pydantic import BaseModel
-
 from smp import file_management as smpfs
 from smp import header as smphdr
-from smp import message as smpmsg
-from tests.helpers import make_assert_header
-
-T = TypeVar("T", bound=smpmsg._MessageBase)
+from tests.helpers import make_do_test
 
 fscmd = smphdr.CommandId.FileManagement
 
-
-def _do_test(
-    msg: Type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.FileManagement,
-    data: Dict[str, Any],
-    nested_model: Type[BaseModel] | None = None,
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.FILE_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            if type(v) is dict and nested_model is not None:
-                for k2, v2 in v.items():
-                    one_deep = getattr(r, k)
-                    assert isinstance(one_deep[k2], nested_model)
-                    assert v2 == one_deep[k2].model_dump()
-            else:
-                assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+_do_test = make_do_test(smphdr.GroupId.FILE_MANAGEMENT)
 
 
 def test_FileDownloadRequest() -> None:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -65,7 +65,7 @@ def test_custom_ReadRequest() -> None:
 )
 @pytest.mark.parametrize("group_id", [USER_GROUP_ID_MIN, 0xFFFF])
 @pytest.mark.parametrize("command_id", [0, 1, 0xFF])
-def test_custom_message(cls: Type[smpmsg._MessageBase], group_id: int, command_id: int) -> None:
+def test_custom_message(cls: Type[smpmsg.SMPData], group_id: int, command_id: int) -> None:
     """Test ReadRequest inheritance."""
 
     class CustomInts(cls):  # type: ignore
@@ -87,7 +87,7 @@ def test_invalid_group_id() -> None:
             _GROUP_ID = 0x10000
             _COMMAND_ID = 0
 
-        A()
+        bytes(A().to_frame())
 
     with pytest.raises(struct.error):
 
@@ -95,7 +95,7 @@ def test_invalid_group_id() -> None:
             _GROUP_ID = -1
             _COMMAND_ID = 0
 
-        B()
+        bytes(B().to_frame())
 
 
 def test_invalid_command_id() -> None:
@@ -107,7 +107,7 @@ def test_invalid_command_id() -> None:
             _GROUP_ID = USER_GROUP_ID_MIN
             _COMMAND_ID = 0x100
 
-        A()
+        bytes(A().to_frame())
 
     with pytest.raises(struct.error):
 
@@ -115,4 +115,4 @@ def test_invalid_command_id() -> None:
             _GROUP_ID = USER_GROUP_ID_MIN
             _COMMAND_ID = -1
 
-        B()
+        bytes(B().to_frame())

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -24,8 +24,8 @@ def test_smpclient_41() -> None:
     assert r.header.sequence == 2
     assert r.header.command_id == smphdr.CommandId.ImageManagement.UPLOAD
 
-    assert r.off == 165
-    assert r.rc == 0
+    assert r.smp_data.off == 165
+    assert r.smp_data.rc == 0
 
     with pytest.raises(ValueError):
         smpimg.ImageManagementErrorV1.loads(RESPONSE)

--- a/tests/test_settings_management.py
+++ b/tests/test_settings_management.py
@@ -2,41 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import settings_management as smpset
-from tests.helpers import make_assert_header
+from tests.helpers import make_do_test
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: Type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.SettingsManagement,
-    data: Dict[str, Any],
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.SETTINGS_MANAGEMENT, op, command_id, len(cbor)
-    )
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+_do_test = make_do_test(smphdr.GroupId.SETTINGS_MANAGEMENT)
 
 
 def test_ReadSettingRequest() -> None:

--- a/tests/test_shell_management.py
+++ b/tests/test_shell_management.py
@@ -2,50 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar
-
-import cbor2
-from pydantic import BaseModel
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import shell_management as smpshell
-from tests.helpers import make_assert_header
+from tests.helpers import make_do_test
 
 shellcmd = smphdr.CommandId.ShellManagement
 
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: Type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.ShellManagement,
-    data: Dict[str, Any],
-    nested_model: Type[BaseModel] | None = None,
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.SHELL_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            if type(v) is dict and nested_model is not None:
-                for k2, v2 in v.items():
-                    one_deep = getattr(r, k)
-                    assert isinstance(one_deep[k2], nested_model)
-                    assert v2 == one_deep[k2].model_dump()
-            else:
-                assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+_do_test = make_do_test(smphdr.GroupId.SHELL_MANAGEMENT)
 
 
 def test_ExecuteRequest() -> None:

--- a/tests/test_statistics_management.py
+++ b/tests/test_statistics_management.py
@@ -2,41 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import statistics_management as smpstat
-from tests.helpers import make_assert_header
+from tests.helpers import make_do_test
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: Type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.StatisticsManagement,
-    data: Dict[str, Any],
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.STATISTICS_MANAGEMENT, op, command_id, len(cbor)
-    )
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+_do_test = make_do_test(smphdr.GroupId.STATISTICS_MANAGEMENT)
 
 
 def test_GroupDataRequest() -> None:

--- a/tests/test_zephyr_management.py
+++ b/tests/test_zephyr_management.py
@@ -2,41 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import zephyr_management as smpz
-from tests.helpers import make_assert_header
+from tests.helpers import make_do_test
 
 zephyrcmd = smphdr.CommandId.ZephyrManagement
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
 
-
-def _do_test(
-    msg: Type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.ZephyrManagement,
-    data: Dict[str, Any],
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.ZEPHYR_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+_do_test = make_do_test(smphdr.GroupId.ZEPHYR_MANAGEMENT)
 
 
 def test_EraseStorageRequest() -> None:

--- a/tests/user/test_intercreate.py
+++ b/tests/user/test_intercreate.py
@@ -11,56 +11,56 @@ def test_initial_ImageUploadWriteRequest() -> None:
         image=0,
         len=132000,
         sha=b"sha",
-    )
+    ).to_frame()
 
     assert_header = make_assert_header(
         ic.header.UserGroupId.INTERCREATE,
         ic.header.OP.WRITE,
         ic.header.CommandId.Intercreate.UPLOAD,
-        len(r.BYTES) - ic.header.Header.SIZE,
+        len(bytes(r)) - ic.header.Header.SIZE,
     )
 
     assert_header(r)
 
-    assert r.off == 0
-    assert r.data == b"test"
-    assert r.image == 0
-    assert r.len == 132000
-    assert r.sha == b"sha"
+    assert r.smp_data.off == 0
+    assert r.smp_data.data == b"test"
+    assert r.smp_data.image == 0
+    assert r.smp_data.len == 132000
+    assert r.smp_data.sha == b"sha"
 
 
 def test_subsequent_ImageUploadWriteRequest() -> None:
     r = ic.ImageUploadWriteRequest(
         off=105000,
         data=b"test",
-    )
+    ).to_frame()
 
     assert_header = make_assert_header(
         ic.header.UserGroupId.INTERCREATE,
         ic.header.OP.WRITE,
         ic.header.CommandId.Intercreate.UPLOAD,
-        len(r.BYTES) - ic.header.Header.SIZE,
+        len(bytes(r)) - ic.header.Header.SIZE,
     )
 
     assert_header(r)
 
-    assert r.off == 105000
-    assert r.data == b"test"
-    assert r.image is None
-    assert r.len is None
-    assert r.sha is None
+    assert r.smp_data.off == 105000
+    assert r.smp_data.data == b"test"
+    assert r.smp_data.image is None
+    assert r.smp_data.len is None
+    assert r.smp_data.sha is None
 
 
 def test_ImageUploadWriteResponse() -> None:
-    r = ic.ImageUploadWriteResponse(sequence=0, off=105000)
+    r = ic.ImageUploadWriteResponse(off=105000).to_frame(sequence=0)
 
     assert_header = make_assert_header(
         ic.header.UserGroupId.INTERCREATE,
         ic.header.OP.WRITE_RSP,
         ic.header.CommandId.Intercreate.UPLOAD,
-        len(r.BYTES) - ic.header.Header.SIZE,
+        len(bytes(r)) - ic.header.Header.SIZE,
     )
 
     assert_header(r)
 
-    assert r.off == 105000
+    assert r.smp_data.off == 105000


### PR DESCRIPTION
Flattening of SMP Data fields into the _MessageBase is replaced by use of a Frame[T]: Frame(Header, T) where T is the generic SMPData.

The _MessageBase class is removed. Commands must
inherit from SMPData instead. to_frame() is available on SMPData instances to create a Frame[T]. Frames
can be serialized like _MessageBase, though BYTES
is removed (bytes() remains).