### PR TITLE
smp: Add forward tree protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smp"
-version = "0"
+version = "4.0.2+forward-tree"
 description = "Simple Management Protocol (SMP) for remotely managing MCU firmware"
 authors = [
 "J.P. Hutchins <jphutchins@gmail.com>",

--- a/smp/header.py
+++ b/smp/header.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import struct
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum, IntFlag, unique
-from typing import ClassVar, Dict, Type, Union
+from typing import ClassVar, Dict, List, Type, Union
 
 from pydantic import Field
 from typing_extensions import Annotated, TypeAlias
@@ -130,6 +130,7 @@ class _VERSION_BIT:
 @unique
 class Flag(IntFlag):
     UNUSED = 0
+    FORWARD_TREE = 0x80
 
 
 @dataclass(frozen=True)
@@ -240,3 +241,79 @@ class Header:
             sequence,
             command_id,
         )
+
+
+@dataclass
+class ForwardTree:
+    ft: List[int] = field(default_factory=list)
+
+    _STRUCT: ClassVar[struct.Struct] = struct.Struct(">Q")
+    SIZE: ClassVar[int] = _STRUCT.size
+
+    @staticmethod
+    def _get_int(nimbles: List[int]) -> int:
+        """Get the 64-bits data from the 16 nibbles"""
+        hops = nimbles[0]
+        if hops > 15:
+            raise ValueError("ForwardTree max hops is 15")
+
+        data = ForwardTree._set_nibble(15, 0, hops)
+        for i in range(hops):
+            data = ForwardTree._set_nibble(hops - i - 1, data, nimbles[i + 1])
+
+        return data
+
+    @staticmethod
+    def _get_nibbles(value: int) -> List[int]:
+        """Get all 16 nibbles"""
+        nibbles = []
+        for i in range(16):
+            nibbles.append(ForwardTree._get_nibble(i, value))
+        return nibbles
+
+    @staticmethod
+    def _get_nibble(index: int, value: int) -> int:
+        """Get specific nibble (0-15)"""
+        if not 0 <= index < 16:
+            raise IndexError("Nibble index must be 0-15")
+        return (value >> ((15 - index) * 4)) & 0xF
+
+    @staticmethod
+    def _set_nibble(index: int, data: int, value: int) -> int:
+        """Set specific nibble (0-15)"""
+        if not 0 <= index < 16:
+            raise IndexError("Nibble index must be 0-15")
+        if not 0 <= value <= 15:
+            raise ValueError("Nibble value must be 0-15")
+
+        # Clear the target nibble
+        mask = ~(0xF << (index * 4))
+        data &= mask
+        # Set the new value
+        data |= (value & 0xF) << (index * 4)
+        return data
+
+    def __post_init__(self) -> None:
+        self._bytes: bytes
+        object.__setattr__(
+            self,
+            '_bytes',
+            self._STRUCT.pack(ForwardTree._get_int(self.ft)),
+        )
+
+    def __bytes__(self) -> bytes:
+        return self._bytes
+
+    @property
+    def BYTES(self) -> bytes:
+        return self._bytes
+
+    @staticmethod
+    def loads(forward: bytes) -> 'ForwardTree':
+        """Deserialize the payload bytes to a `ForwardTree`."""
+        assert len(forward) == 8, "The ForwardTree is specified as 8 bytes"
+
+        data64 = ForwardTree._STRUCT.unpack(forward)
+        nimbles = ForwardTree._get_nibbles(data64)
+
+        return ForwardTree(nimbles)

--- a/smp/message.py
+++ b/smp/message.py
@@ -6,7 +6,8 @@ import itertools
 import logging
 from abc import ABC
 from enum import IntEnum, unique
-from typing import ClassVar, Type, TypeVar, cast
+from typing import Any, ClassVar, Type, TypeVar, cast
+from dataclasses import replace
 
 import cbor2
 from pydantic import BaseModel, ConfigDict
@@ -43,6 +44,7 @@ class _MessageBase(ABC, BaseModel):
     version: smpheader.Version = smpheader.Version.V2
     sequence: int = None  # type: ignore
     smp_data: bytes = None  # type: ignore
+    forward_tree: smpheader.ForwardTree = None  # type: ignore
 
     def __bytes__(self) -> bytes:
         return self.smp_data
@@ -65,6 +67,11 @@ class _MessageBase(ABC, BaseModel):
             raise SMPMismatchedGroupId(
                 f"{cls.__name__} has {cls._GROUP_ID}, header has {message.header.group_id}"
             )
+        if message.header.flags & smpheader.Flag.FORWARD_TREE:
+            message.forward_tree = smpheader.ForwardTree.loads(message.smp_data[-8:])
+            message.smp_data = message.smp_data[:-8]
+            message.header.length = message.header.length-8
+
         return message
 
     @classmethod
@@ -80,11 +87,12 @@ class _MessageBase(ABC, BaseModel):
         data_bytes = cbor2.dumps(
             self.model_dump(
                 exclude_unset=True,
-                exclude={'header', 'version', 'sequence', 'smp_data'},
+                exclude={'header', 'version', 'sequence', 'smp_data', 'forward_tree'},
                 exclude_none=True,
             ),
             canonical=True,
         )
+        is_forward_tree = False
         if self.header is None:  # create the header
             object.__setattr__(
                 self,
@@ -101,9 +109,11 @@ class _MessageBase(ABC, BaseModel):
             )
             object.__setattr__(self, 'sequence', self.header.sequence)
         else:  # validate the header and update version & sequence
-            if self.smp_data is None and self.header.length != len(data_bytes):
+            is_forward_tree = (self.header.flags & smpheader.Flag.FORWARD_TREE) > 0
+            length = len(data_bytes) + smpheader.ForwardTree.SIZE if is_forward_tree else 0
+            if self.smp_data is None and self.header.length != length:
                 raise SMPMalformed(
-                    f"header.length {self.header.length} != len(data_bytes) {len(data_bytes)}"
+                    f"header.length {self.header.length} != len(data_bytes) {length}"
                 )
             if self.sequence is not None:  # pragma: no cover
                 raise ValueError(
@@ -117,8 +127,20 @@ class _MessageBase(ABC, BaseModel):
                     "from the provided header."
                 )
             object.__setattr__(self, 'version', self.header.version)
+            if self.forward_tree is None and is_forward_tree:
+                print(self.forward_tree)
+                object.__setattr__(self, 'forward_tree', self.forward_tree)
         if self.smp_data is None:
-            object.__setattr__(self, 'smp_data', bytes(self.header) + data_bytes)
+            forward = bytes(self.forward_tree) if is_forward_tree else b''
+            object.__setattr__(self, 'smp_data', bytes(self.header) + data_bytes + forward)
+
+    def set_header(self, **header_kwargs: Any) -> '_MessageBase':
+        new_header = replace(self.header, **header_kwargs)
+        return self.model_copy(update={'header': new_header})
+
+    def set_forward(self, forward: smpheader.ForwardTree) -> '_MessageBase':
+        return self.model_copy(update={'forward_tree': forward})
+
 
     # # Uncomment this to create a record for a de/serialization regression lock
     #     self._log_serialized_bytes()
@@ -131,7 +153,7 @@ class _MessageBase(ABC, BaseModel):
 
     #     kwargs = self.model_dump(
     #         exclude_unset=True,
-    #         exclude={'header', 'version', 'sequence', 'smp_data'},
+    #         exclude={'header', 'version', 'sequence', 'smp_data', 'forward_tree'},
     #         exclude_none=True,
     #     )
 


### PR DESCRIPTION
smp: Add forward tree protocol

Introduce the Forward Tree protocol (FT). The FT route data downstream in a tree of MCUmgr devices. The Flag 0x80 was selected to indicate that the data payload contains additionally the FT 8 bytes. This 8 bytes are placed at end of regular group payload.

The FT payload is composed by 16 nimbles. The first nimble is the number of hops down in the tree, which in total can handle 15. The remaining nimbles identify the downstream port index.

The FT is a generic downstream route protocol mechanism and it is not designed to create network were a downstream device can send communication upstream or downstream.
    
```
    FT example:
                              host
                               |
                               D1
                              /|\
                         ----- | -----
                        /      D3     \
                       D2      |      D4
                              / \
                      D5------   ------D6
```
    
The host is the controller which sends SMP requests. This means that data flows from host to devices in the downstream direction. A response from a device to host is the upstream direction.

In this scenario, all upstream messages are processed as a transparent forward response to the host or without any changes the content.

A downstream message needs to be inspected when the FORWARD_TREE flag bit (0x80) is set. The FT payload format is compose by 16 nimbles. The most left nimble is the hops counter. All the other nimbles are port indexes.
    
```
           ---- Nimble 15       ---- Nimble 1
          /                    /
      0xH0'00'00'00'00'00'00'0N
        \
         --- hops
```
    
Assuming that the host wants to send data to D4 device:

1- set the hops property to 1
2- add the FT port[0] nimble as 2

The correspondent FT big endian data payload in the wire will be:
    
```
                                ---- Nimble 1
                               /
      0x10'00'00'00'00'00'00'02
        \
         --- hops
```
    
In this case, when host send the data to D1 the device will inspect the
content and forward downstream in the D1 port[2], where D4 is connected.

In the same way, when host wants to send a request to D6:

1- set the hops property to 2
2- set the FT port[1] nimble to 1 and port[0] nimble to 1
    
```
                                ---- Ninble 1
                               /---- Nimble 0
                              //
      0x20'00'00'00'00'00'00'11
        \
         --- hops
```
    
This means that each time a device must inspect the FT payload and forward downstream the hops count should be reduced by 1 and when hops is evaluated to 0 the device must consume the package.

The system will use the hops value to index the correspondent FT port nimble. In summary, the FT lower port index represents the route closer to the destine and the high port index represents the node closer to the device that start the request.

Forward Tree Protocol proposal:
<img width="578" height="255" alt="image" src="https://github.com/user-attachments/assets/d87bd377-3c41-4c66-b726-95b1479c3da0" />

CC: @otavio