### PR TITLE
fix: default line length 8192 -> 127

### DIFF
--- a/smp/packet.py
+++ b/smp/packet.py
@@ -27,7 +27,7 @@ crc16_func: Final = mkPredefinedCrcFun("xmodem")
 logger: Final = logging.getLogger(__name__)
 
 
-def encode(request: bytes, line_length: int = 8192) -> Generator[bytes, None, None]:
+def encode(request: bytes, line_length: int = 127) -> Generator[bytes, None, None]:
     """Iteratively pack an SMP bytes to packets of `line_length` size.
 
     Note: only the USB/serial transport uses this encoding and fragmentation.

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -44,7 +44,9 @@ def _assert_payload(frame: bytes, data: bytes) -> None:
     assert data == r.data
 
 
-@pytest.mark.parametrize("line_length", [16, 20, 89, 128, 251, 313, 512, 1024, 1609, 4096, 8192])
+@pytest.mark.parametrize(
+    "line_length", [16, 20, 89, 127, 128, 251, 313, 512, 1024, 1609, 4096, 8192]
+)
 @pytest.mark.parametrize("line_length_ratio", [0.1, 1 / 3, 0.5, 1, 2, 3, 4, 7])
 def test_encode(line_length: int, line_length_ratio: float) -> None:
     data = bytes([i % 0xFF for i in range(round(line_length * line_length_ratio))])
@@ -83,7 +85,9 @@ def test_encode(line_length: int, line_length_ratio: float) -> None:
         remaining = remaining[frame_length + 2 :]
 
 
-@pytest.mark.parametrize("line_length", [16, 20, 89, 128, 251, 313, 512, 1024, 1609, 4096, 8192])
+@pytest.mark.parametrize(
+    "line_length", [16, 20, 89, 127, 128, 251, 313, 512, 1024, 1609, 4096, 8192]
+)
 @pytest.mark.parametrize("line_length_ratio", [0.1, 1 / 3, 0.5, 1, 2, 3, 4, 7])
 def test_decode(line_length: int, line_length_ratio: float) -> None:
     data = bytes([i % 0xFF for i in range(round(line_length * line_length_ratio))])


### PR DESCRIPTION
See https://github.com/intercreate/smpclient/issues/73 for a discussion of why 127 should be default.