### PR TITLE
test: add `slow` marker and a fast_test task (<5s core coverage)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ exclude = ['\.venv']
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+"slow: exhaustive combinatorial sweeps; deselected by the fast_test task",
+]
 
 [tool.coverage.run]
 source = ["smp"]

--- a/tasks.py
+++ b/tasks.py
@@ -14,12 +14,13 @@ mypy = Task("uv run mypy src tests")
 pyright = Task("uv run pyright src tests")
 typecheck = Parallel(mypy, pyright)
 test = Task("uv run pytest")
+fast_test = Task("uv run pytest -m 'not slow' --ignore=tests/binary_regressions")
 coverage = Task("uv run pytest --cov=smp --cov-report=term-missing --cov-report=xml")
 docs = Task("uv run --group doc mkdocs build")
 
 check = Parallel(format_check, lint, typecheck, test)
 gate = Parallel(format_check, lint, typecheck, coverage)
-fast = Sequential(format_check, Parallel(lint, typecheck))
+fast = Sequential(format_check, Parallel(lint, typecheck, fast_test))
 all = Sequential(fix, Parallel(typecheck, coverage))
 
 matrix = Parallel(

--- a/tests/binary_regressions/test_binary_lock.py
+++ b/tests/binary_regressions/test_binary_lock.py
@@ -10,6 +10,8 @@ import pytest
 import smp.message as smpmsg
 from smp.file_management import FileHashChecksumResponse
 
+pytestmark = pytest.mark.slow
+
 
 class Record(NamedTuple):
     message: str

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -6,6 +6,8 @@ import pytest
 
 from smp.header import OP, Flag, GroupId, Header, Version
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.mark.parametrize("op", [OP.READ, OP.READ_RSP, OP.WRITE, OP.WRITE_RSP])
 @pytest.mark.parametrize("version", [Version.V1, Version.V2])

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -33,6 +33,7 @@ def test_ImageStatesReadRequest() -> None:
     assert len(r.BYTES) == smpheader.Header.SIZE + 1
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("slot", [0, 1])
 @pytest.mark.parametrize("version", ["0.1.0"])
 @pytest.mark.parametrize("image", [0, 1, None])


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8 on behalf of @JPHutchins, who asked me to add a `fast_test` camas task using pytest markers that gives reasonable coverage in under 5s (no multi-core), as a small follow-up to the uv + camas migration (#63).

Adds a **`fast_test`** task for the inner development loop: reasonable coverage in **~3s** instead of ~68s for the full suite.

## Why

Profiling the suite showed the ~68s is **volume, not slow tests** (slowest single test = 0.31s). ~98% of the 40,976 tests live in three exhaustive combinatorial sweeps:

| module | tests |
| --- | --- |
| `tests/binary_regressions/test_binary_lock.py` | 27,435 |
| `tests/test_image_management.py::test_ImageStatesReadResponse` | 8,748 |
| `tests/test_header.py` | 3,888 |

The other ~905 tests are the fast "core" — and on their own they already reach **99% line coverage** (the sweeps only add the last ~1%: a couple of validation-error branches and a field validator).

## What changed

- Register a **`slow`** pytest marker and apply it to the three sweeps (whole-module for `test_binary_lock`/`test_header`, function-level for `test_ImageStatesReadResponse` so its ~79 non-combinatorial tests stay in `fast_test`).
- **`fast_test = uv run pytest -m 'not slow' --ignore=tests/binary_regressions`.** The marker does the deselection. The one `--ignore` is there because `binary_regressions` reads 27k records from JSON **at import**, so ~2.7s of *collection* cost a marker can't avoid; header/image collect cheaply, so the marker alone handles them.
- Wire `fast_test` into the default **`fast`** task, which previously ran **no** tests.

No multi-core / xdist — matches the "init overhead" concern.

## Verification

- `camas fast_test` → **905 passed, 12,636 deselected in 2.83s** (~3.9s wall through camas).
- `camas gate` → green (ruff, mypy, pyright) and the full coverage run still executes **all 40,976 tests at 100%** — the `test`/`coverage`/`matrix` paths carry no `-m` filter, so they're unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq2MMZAtCoSitXj3GQ5Lcz
