### PR TITLE
breaking: screaming-goblin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.10"
 dependencies = [
 "cbor2>=6,<7",
 "crcmod>=1.7,<2",
-"pydantic>=2.6,<3",
+"msgspec>=0.21.1",
+"msgspec-cbor>=0.2,<0.3",
 ]
 dynamic = ["version"]
 classifiers = [
@@ -72,7 +73,7 @@ extend-select = [
 ]
 
 [tool.ruff.lint.flake8-type-checking]
-runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+runtime-evaluated-base-classes = ["msgspec.Struct"]
 
 [tool.ruff.format]
 quote-style = "preserve"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "pytest-cov>=7,<8",
     "camas[mcp]==0.1.25",
     "pyright>=1.1,<2",
+    "typing-extensions>=4,<5",
 ]
 doc = [
 "mkdocstrings[python]>=0.26.1,<1",
@@ -81,6 +82,10 @@ quote-style = "preserve"
 [tool.mypy]
 disallow_untyped_defs = true
 exclude = ['\.venv']
+
+[tool.pyright]
+include = ["src", "tests"]
+typeCheckingMode = "standard"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/smp/__init__.py
+++ b/src/smp/__init__.py
@@ -95,3 +95,33 @@ All models are validated in order to detect transport and SMP server errors.  It
 is impossible to create an invalid SMP message or deserialize an invalid SMP
 message.  If you find a way, please open an issue.
 """
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from smp import error as smperror
+    from smp import message as smpmessage
+
+_TRep_co = TypeVar(
+    "_TRep_co", bound="smpmessage.ReadResponse | smpmessage.WriteResponse", covariant=True
+)
+_TEr1_co = TypeVar("_TEr1_co", bound="smperror.ErrorV1", covariant=True)
+_TEr2_co = TypeVar("_TEr2_co", bound="smperror.ErrorV2", covariant=True)
+
+
+class SMPRequest(Protocol[_TRep_co, _TEr1_co, _TEr2_co]):
+    """A `Request` bound to its expected `Response`, `ErrorV1`, and `ErrorV2`.
+
+    An `SMPRequest` binds a `Request` to the `Response`, `ErrorV1`, and `ErrorV2`
+    it may provoke, so that a request/response round trip is exhaustively typed.
+    """
+
+    @property
+    def _Response(self) -> type[_TRep_co]: ...
+    @property
+    def _ErrorV1(self) -> type[_TEr1_co]: ...
+    @property
+    def _ErrorV2(self) -> type[_TEr2_co]: ...
+    def to_frame(self) -> smpmessage.Frame[Any]: ...

--- a/src/smp/enumeration_management.py
+++ b/src/smp/enumeration_management.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from enum import IntEnum, unique
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+import msgspec
 
 import smp.error as smperr
 import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class GroupCountRequest(smpmsg.ReadRequest):
+class GroupCountRequest(smpmsg.ReadRequest, frozen=True):
     """Read the number of SMP server groups.
 
     Count of supported groups returns the total number of SMP command groups
@@ -22,7 +23,7 @@ class GroupCountRequest(smpmsg.ReadRequest):
     _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_COUNT
 
 
-class GroupCountResponse(smpmsg.ReadResponse):
+class GroupCountResponse(smpmsg.ReadResponse, frozen=True):
     """SMP group count response."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
@@ -32,14 +33,14 @@ class GroupCountResponse(smpmsg.ReadResponse):
     """Contains the total number of supported SMP groups on the device."""
 
 
-class ListOfGroupsRequest(smpmsg.ReadRequest):
+class ListOfGroupsRequest(smpmsg.ReadRequest, frozen=True):
     """List the available SMP groups."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.EnumManagement.LIST_OF_GROUPS
 
 
-class ListOfGroupsResponse(smpmsg.ReadResponse):
+class ListOfGroupsResponse(smpmsg.ReadResponse, frozen=True):
     """SMP group list response."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
@@ -48,8 +49,14 @@ class ListOfGroupsResponse(smpmsg.ReadResponse):
     groups: tuple[smphdr.GroupIdField, ...]
     """Contains a list of the supported SMP group IDs on the device."""
 
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> ListOfGroupsResponse:
+        cls._validate_mapping(data)
+        raw = msgspec.convert(data["groups"], type=tuple[int, ...])
+        return cls(groups=tuple(smphdr.resolve_group_id(g) for g in raw))
 
-class GroupIdRequest(smpmsg.ReadRequest):
+
+class GroupIdRequest(smpmsg.ReadRequest, frozen=True):
     """List a SMP group by index.
 
     Fetch single group ID command allows listing the group IDs of supported SMP
@@ -65,7 +72,7 @@ class GroupIdRequest(smpmsg.ReadRequest):
 """
 
 
-class GroupIdResponse(smpmsg.ReadResponse):
+class GroupIdResponse(smpmsg.ReadResponse, frozen=True):
     """SMP group at index response."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
@@ -78,8 +85,16 @@ class GroupIdResponse(smpmsg.ReadResponse):
     the device, otherwise will be omitted.
     """
 
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> GroupIdResponse:
+        cls._validate_mapping(data)
+        return cls(
+            group=smphdr.resolve_group_id(msgspec.convert(data["group"], type=int)),
+            end=msgspec.convert(data["end"], type=bool) if "end" in data else None,
+        )
 
-class GroupDetailsRequest(smpmsg.ReadRequest):
+
+class GroupDetailsRequest(smpmsg.ReadRequest, frozen=True):
     """Request the details of the supported SMP groups.
 
     Details on supported groups command allows fetching details on each
@@ -102,11 +117,17 @@ class GroupDetailsRequest(smpmsg.ReadRequest):
     If omitted, details on all supported groups will be returned.
     """
 
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> GroupDetailsRequest:
+        cls._validate_mapping(data)
+        if "groups" not in data:
+            return cls()
+        raw = msgspec.convert(data["groups"], type=tuple[int, ...])
+        return cls(groups=tuple(smphdr.resolve_group_id(g) for g in raw))
 
-class GroupDetails(BaseModel):
+
+class GroupDetails(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
     """Group Details"""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
 
     group: smphdr.GroupIdField
     """The group ID of the SMP command group."""
@@ -116,7 +137,15 @@ class GroupDetails(BaseModel):
     """The number of handlers that the SMP command group supports."""
 
 
-class GroupDetailsResponse(smpmsg.ReadResponse):
+class _GroupDetailsWire(
+    msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True
+):
+    group: int
+    name: str | None = None
+    handlers: int | None = None
+
+
+class GroupDetailsResponse(smpmsg.ReadResponse, frozen=True):
     """SMP group details response."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
@@ -124,6 +153,21 @@ class GroupDetailsResponse(smpmsg.ReadResponse):
 
     groups: tuple[GroupDetails, ...]
     """Contains a list of the requested SMP group details."""
+
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> GroupDetailsResponse:
+        cls._validate_mapping(data)
+        wires = msgspec.convert(data["groups"], type=tuple[_GroupDetailsWire, ...])
+        return cls(
+            groups=tuple(
+                GroupDetails(
+                    group=smphdr.resolve_group_id(w.group),
+                    name=w.name,
+                    handlers=w.handlers,
+                )
+                for w in wires
+            )
+        )
 
 
 @unique
@@ -146,13 +190,13 @@ class ENUM_MGMT_ERR(IntEnum):
     """Provided index is larger than the number of supported groups."""
 
 
-class EnumManagementErrorV1(smperr.ErrorV1):
+class EnumManagementErrorV1(smperr.ErrorV1, frozen=True):
     """Error response to a enumeration management command."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
 
 
-class EnumManagementErrorV2(smperr.ErrorV2[ENUM_MGMT_ERR]):
+class EnumManagementErrorV2(smperr.ErrorV2[ENUM_MGMT_ERR], frozen=True):
     """Error response to a enumeration management command."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT

--- a/src/smp/enumeration_management.py
+++ b/src/smp/enumeration_management.py
@@ -12,15 +12,41 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class GroupCountRequest(smpmsg.ReadRequest, frozen=True):
-    """Read the number of SMP server groups.
+@unique
+class ENUM_MGMT_ERR(IntEnum):
+    """Return codes for the enumeration management group."""
 
-    Count of supported groups returns the total number of SMP command groups
-    that a device supports.
-    """
+    OK = 0
+    """No error, this is implied if there is no ret value in the response."""
+
+    UNKNOWN = 1
+    """Unknown error occurred."""
+
+    ERR_TOO_MANY_GROUP_ENTRIES = 2
+    """Too many entries were provided."""
+
+    ERR_INSUFFICIENT_HEAP_FOR_ENTRIES = 3
+    """Insufficient heap memory to store entry data."""
+
+    ENUM_MGMT_ERR_INDEX_TOO_LARGE = 4
+    """Provided index is larger than the number of supported groups."""
+
+
+class EnumManagementErrorV1(smperr.ErrorV1, frozen=True):
+    """Error response to a enumeration management command."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_COUNT
+
+
+class EnumManagementErrorV2(smperr.ErrorV2[ENUM_MGMT_ERR], frozen=True):
+    """Error response to a enumeration management command."""
+
+    _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
+
+
+class _EnumGroupBase:
+    _ErrorV1 = EnumManagementErrorV1
+    _ErrorV2 = EnumManagementErrorV2
 
 
 class GroupCountResponse(smpmsg.ReadResponse, frozen=True):
@@ -33,11 +59,16 @@ class GroupCountResponse(smpmsg.ReadResponse, frozen=True):
     """Contains the total number of supported SMP groups on the device."""
 
 
-class ListOfGroupsRequest(smpmsg.ReadRequest, frozen=True):
-    """List the available SMP groups."""
+class GroupCountRequest(smpmsg.ReadRequest, _EnumGroupBase, frozen=True):
+    """Read the number of SMP server groups.
+
+    Count of supported groups returns the total number of SMP command groups
+    that a device supports.
+    """
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.EnumManagement.LIST_OF_GROUPS
+    _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_COUNT
+    _Response = GroupCountResponse
 
 
 class ListOfGroupsResponse(smpmsg.ReadResponse, frozen=True):
@@ -56,20 +87,12 @@ class ListOfGroupsResponse(smpmsg.ReadResponse, frozen=True):
         return cls(groups=tuple(smphdr.resolve_group_id(g) for g in raw))
 
 
-class GroupIdRequest(smpmsg.ReadRequest, frozen=True):
-    """List a SMP group by index.
-
-    Fetch single group ID command allows listing the group IDs of supported SMP
-    groups on the device, one by one.
-    """
+class ListOfGroupsRequest(smpmsg.ReadRequest, _EnumGroupBase, frozen=True):
+    """List the available SMP groups."""
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_ID
-
-    index: int | None = None
-    """Contains the (0-based) index of the group to return information on, can
-    be omitted to return the first group's details.
-"""
+    _COMMAND_ID = smphdr.CommandId.EnumManagement.LIST_OF_GROUPS
+    _Response = ListOfGroupsResponse
 
 
 class GroupIdResponse(smpmsg.ReadResponse, frozen=True):
@@ -94,36 +117,21 @@ class GroupIdResponse(smpmsg.ReadResponse, frozen=True):
         )
 
 
-class GroupDetailsRequest(smpmsg.ReadRequest, frozen=True):
-    """Request the details of the supported SMP groups.
+class GroupIdRequest(smpmsg.ReadRequest, _EnumGroupBase, frozen=True):
+    """List a SMP group by index.
 
-    Details on supported groups command allows fetching details on each
-    supported SMP group, such as the name and number of handlers. A device can
-    specify an allow list of groups to return details on or details on all
-    groups can be returned.
-
-    This command is optional, it can be enabled using
-    `CONFIG_MCUMGR_GRP_ENUM_DETAILS`. The optional name and number of handlers
-    can be enabled/disabled with `CONFIG_MCUMGR_GRP_ENUM_DETAILS_NAME` and
-    `CONFIG_MCUMGR_GRP_ENUM_DETAILS_HANDLERS`.
+    Fetch single group ID command allows listing the group IDs of supported SMP
+    groups on the device, one by one.
     """
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_DETAILS
+    _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_ID
+    _Response = GroupIdResponse
 
-    groups: tuple[smphdr.GroupIdField, ...] | None = None
-    """Contains a list of the SMP group IDs to fetch details on.
-
-    If omitted, details on all supported groups will be returned.
-    """
-
-    @classmethod
-    def _convert_mapping(cls, data: dict[str, Any]) -> GroupDetailsRequest:
-        cls._validate_mapping(data)
-        if "groups" not in data:
-            return cls()
-        raw = msgspec.convert(data["groups"], type=tuple[int, ...])
-        return cls(groups=tuple(smphdr.resolve_group_id(g) for g in raw))
+    index: int | None = None
+    """Contains the (0-based) index of the group to return information on, can
+    be omitted to return the first group's details.
+"""
 
 
 class GroupDetails(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
@@ -170,33 +178,34 @@ class GroupDetailsResponse(smpmsg.ReadResponse, frozen=True):
         )
 
 
-@unique
-class ENUM_MGMT_ERR(IntEnum):
-    """Return codes for the enumeration management group."""
+class GroupDetailsRequest(smpmsg.ReadRequest, _EnumGroupBase, frozen=True):
+    """Request the details of the supported SMP groups.
 
-    OK = 0
-    """No error, this is implied if there is no ret value in the response."""
+    Details on supported groups command allows fetching details on each
+    supported SMP group, such as the name and number of handlers. A device can
+    specify an allow list of groups to return details on or details on all
+    groups can be returned.
 
-    UNKNOWN = 1
-    """Unknown error occurred."""
-
-    ERR_TOO_MANY_GROUP_ENTRIES = 2
-    """Too many entries were provided."""
-
-    ERR_INSUFFICIENT_HEAP_FOR_ENTRIES = 3
-    """Insufficient heap memory to store entry data."""
-
-    ENUM_MGMT_ERR_INDEX_TOO_LARGE = 4
-    """Provided index is larger than the number of supported groups."""
-
-
-class EnumManagementErrorV1(smperr.ErrorV1, frozen=True):
-    """Error response to a enumeration management command."""
+    This command is optional, it can be enabled using
+    `CONFIG_MCUMGR_GRP_ENUM_DETAILS`. The optional name and number of handlers
+    can be enabled/disabled with `CONFIG_MCUMGR_GRP_ENUM_DETAILS_NAME` and
+    `CONFIG_MCUMGR_GRP_ENUM_DETAILS_HANDLERS`.
+    """
 
     _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.EnumManagement.GROUP_DETAILS
+    _Response = GroupDetailsResponse
 
+    groups: tuple[smphdr.GroupIdField, ...] | None = None
+    """Contains a list of the SMP group IDs to fetch details on.
 
-class EnumManagementErrorV2(smperr.ErrorV2[ENUM_MGMT_ERR], frozen=True):
-    """Error response to a enumeration management command."""
+    If omitted, details on all supported groups will be returned.
+    """
 
-    _GROUP_ID = smphdr.GroupId.ENUM_MANAGEMENT
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> GroupDetailsRequest:
+        cls._validate_mapping(data)
+        if "groups" not in data:
+            return cls()
+        raw = msgspec.convert(data["groups"], type=tuple[int, ...])
+        return cls(groups=tuple(smphdr.resolve_group_id(g) for g in raw))

--- a/src/smp/error.py
+++ b/src/smp/error.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar, get_args, get_origin
 
-from pydantic import BaseModel, ConfigDict
+import msgspec
 
-from smp import message
-from smp.header import GroupIdField
+from smp import header, message
 
 T = TypeVar("T", bound=IntEnum)
 
@@ -63,7 +62,7 @@ class MGMT_ERR(IntEnum):
     """User errors defined from 256 onwards"""
 
 
-class ErrorV1(message.Response):
+class ErrorV1(message.Response, frozen=True):
     """SMP error response version 1."""
 
     RESPONSE_TYPE = message.ResponseType.ERROR_V1
@@ -75,18 +74,39 @@ class ErrorV1(message.Response):
     """Error reason."""
 
 
-class Err(BaseModel, Generic[T]):
+class Err(msgspec.Struct, Generic[T], frozen=True, omit_defaults=True, forbid_unknown_fields=True):
     """SMP error response version 2 `err` map."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True, arbitrary_types_allowed=True)
-
-    group: GroupIdField
+    group: header.GroupIdField
     rc: T
 
 
-class ErrorV2(message.Response, Generic[T]):
+class _ErrWire(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
+    group: int
+    rc: int
+
+
+class ErrorV2(message.Response, Generic[T], frozen=True):
     """SMP error response version 2."""
 
     RESPONSE_TYPE = message.ResponseType.ERROR_V2
 
     err: Err[T]
+
+    @classmethod
+    def _rc_type(cls) -> Any:
+        for base in getattr(cls, "__orig_bases__", ()):
+            if get_origin(base) is ErrorV2:
+                return get_args(base)[0]
+        raise TypeError(f"{cls.__name__} does not parametrize {ErrorV2.__name__}")
+
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> ErrorV2[T]:
+        cls._validate_mapping(data)
+        wire = msgspec.convert(data["err"], type=_ErrWire)
+        return cls(
+            err=Err(
+                group=header.resolve_group_id(wire.group),
+                rc=msgspec.convert(wire.rc, type=cls._rc_type()),
+            )
+        )

--- a/src/smp/file_management.py
+++ b/src/smp/file_management.py
@@ -10,192 +10,6 @@ import msgspec
 from smp import error, header, message
 
 
-class FileDownloadRequest(message.ReadRequest, frozen=True):
-    """Download contents of an existing file from specified path.
-
-    Client applications must keep track of data they have already downloaded and
-    where their position in the file is, and issue subsequent requests, with
-    modified offset, to gather the entire file.
-
-    Request does not carry size of requested chunk, the size is specified by
-    application itself. Note that file handles will remain open for consecutive
-    requests (as long as an idle timeout has not been reached and another
-    transport does not make use of uploading/downloading files using fs_mgmt),
-    but files are not exclusively owned by SMP, for the time of download
-    session, and may change between requests or even be removed.
-    """
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
-
-    off: int
-    """Offset in the file to read from."""
-    name: str
-    """Name of the file to download."""
-
-
-class FileDownloadResponse(message.ReadResponse, frozen=True):
-    """Success response to a file download request."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
-
-    off: int
-    """Offset that this response is for."""
-    data: bytes
-    """Data read from the file."""
-    len: int | None = None
-    """The length of the file, only mandatory if “off” is 0."""
-
-
-class FileUploadRequest(message.WriteRequest, frozen=True):
-    """Upload a file to a specified location.
-
-    Command will automatically overwrite existing file or create a new one if it
-    does not exist at specified path. The protocol supports stateless upload
-    where each requests carries different chunk of a file and it is client side
-    responsibility to track progress of upload.
-
-    Note that file handles will remain open for consecutive requests (as long as
-    an idle timeout has not been reached, but files are not exclusively owned by
-    SMP, for the time of download session, and may change between requests or
-    even be removed. Note that file handles will remain open for consecutive
-    requests (as long as an idle timeout has not been reached and another
-    transport does not make use of uploading/downloading files using fs_mgmt),
-    but files are not exclusively owned by MCUmgr, for the time of download
-    session, and may change between requests or even be removed.
-    """
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
-
-    off: int
-    """Offset to start/continue writing to."""
-    data: bytes
-    """Data to write to the file."""
-    name: str
-    """Name of the file to upload."""
-    len: int | None = None
-    """The length of the file, only mandatory if “off” is 0."""
-
-
-class FileUploadResponse(message.WriteResponse, frozen=True):
-    """Success response to a file upload request."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
-
-    off: int
-    """Offset of the file."""
-
-
-class FileStatusRequest(message.ReadRequest, frozen=True):
-    """Retrieve status of an existing file from specified path of a target device."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_STATUS
-
-    name: str
-
-
-class FileStatusResponse(message.ReadResponse, frozen=True):
-    """Success response to a file status request."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_STATUS
-
-    len: int
-
-
-class FileHashChecksumRequest(message.ReadRequest, frozen=True):
-    """Generate a hash/checksum of an existing file at a specified path on a target device.
-
-    Note that kernel heap memory is required for buffers to be allocated for
-    this to function, and large stack memory buffers are required for generation
-    of the output hash/checksum. Requires `CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH` to
-    be enabled for the base functionality, supported hash/checksum are opt-in
-    with `CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32` or
-    `CONFIG_MCUMGR_GRP_FS_HASH_SHA256`.
-    """
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_HASH_CHECKSUM
-
-    name: str
-    """Absolute path to the file to generate hash/checksum for."""
-    type: Literal["crc32", "sha256"] | None = None
-    """Type of hash/checksum to generate, if not provided, default is used."""
-    off: int | None = None
-    """Offset to start hash/checksum generation from, default 0."""
-    len: int | None = None
-    """Maximum length of the file to generate hash/checksum for, default is entire file."""
-
-
-class FileHashChecksumResponse(message.ReadResponse, frozen=True):
-    """Success response to a file hash/checksum request."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_HASH_CHECKSUM
-
-    type: Literal["crc32", "sha256"]
-    len: int
-    """Length of input data used to generate hash/checksum."""
-    output: int | bytes
-    """Output hash/checksum, depending on the type requested."""
-    off: int | None = None
-    """Only present if not 0."""
-
-
-class SupportedFileHashChecksumTypesRequest(message.ReadRequest, frozen=True):
-    """List the hash and checksum types are available on a device.
-
-    Requires Kconfig `CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD` to be enabled.
-    """
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.SUPPORTED_FILE_HASH_CHECKSUM_TYPES
-
-
-class HashChecksumFormat(IntEnum):
-    """Format that the hash/checksum returns where 0 is for numerical and 1 is for byte array."""
-
-    NUMERICAL = 0
-    BYTE_ARRAY = 1
-
-
-class HashChecksumType(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
-    """Hash and checksum type supported by the device."""
-
-    format: HashChecksumFormat
-    """Format that the hash/checksum returns where 0 is for numerical and 1 is for byte array."""
-    size: int
-    """Size of the hash/checksum in bytes."""
-
-
-class SupportedFileHashChecksumTypesResponse(message.ReadResponse, frozen=True):
-    """Success response to a supported file hash/checksum types request."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.SUPPORTED_FILE_HASH_CHECKSUM_TYPES
-
-    types: dict[Literal["crc32", "sha256"], HashChecksumType]
-    """The map of supported hash/checksum types."""
-
-
-class FileCloseRequest(message.WriteRequest, frozen=True):
-    """Close all open file handles held by fs_mgmt upload/download requests."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_CLOSE
-
-
-class FileCloseResponse(message.WriteResponse, frozen=True):
-    """Success response to a file close request."""
-
-    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.FileManagement.FILE_CLOSE
-
-
 @unique
 class FS_MGMT_ERR(IntEnum):
     """File System Management error codes."""
@@ -266,3 +80,200 @@ class FileSystemManagementErrorV2(error.ErrorV2[FS_MGMT_ERR], frozen=True):
     """File System Management error response."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+
+
+class _FileGroupBase:
+    _ErrorV1 = FileSystemManagementErrorV1
+    _ErrorV2 = FileSystemManagementErrorV2
+
+
+class FileDownloadResponse(message.ReadResponse, frozen=True):
+    """Success response to a file download request."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
+
+    off: int
+    """Offset that this response is for."""
+    data: bytes
+    """Data read from the file."""
+    len: int | None = None
+    """The length of the file, only mandatory if “off” is 0."""
+
+
+class FileDownloadRequest(message.ReadRequest, _FileGroupBase, frozen=True):
+    """Download contents of an existing file from specified path.
+
+    Client applications must keep track of data they have already downloaded and
+    where their position in the file is, and issue subsequent requests, with
+    modified offset, to gather the entire file.
+
+    Request does not carry size of requested chunk, the size is specified by
+    application itself. Note that file handles will remain open for consecutive
+    requests (as long as an idle timeout has not been reached and another
+    transport does not make use of uploading/downloading files using fs_mgmt),
+    but files are not exclusively owned by SMP, for the time of download
+    session, and may change between requests or even be removed.
+    """
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
+    _Response = FileDownloadResponse
+
+    off: int
+    """Offset in the file to read from."""
+    name: str
+    """Name of the file to download."""
+
+
+class FileUploadResponse(message.WriteResponse, frozen=True):
+    """Success response to a file upload request."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
+
+    off: int
+    """Offset of the file."""
+
+
+class FileUploadRequest(message.WriteRequest, _FileGroupBase, frozen=True):
+    """Upload a file to a specified location.
+
+    Command will automatically overwrite existing file or create a new one if it
+    does not exist at specified path. The protocol supports stateless upload
+    where each requests carries different chunk of a file and it is client side
+    responsibility to track progress of upload.
+
+    Note that file handles will remain open for consecutive requests (as long as
+    an idle timeout has not been reached, but files are not exclusively owned by
+    SMP, for the time of download session, and may change between requests or
+    even be removed. Note that file handles will remain open for consecutive
+    requests (as long as an idle timeout has not been reached and another
+    transport does not make use of uploading/downloading files using fs_mgmt),
+    but files are not exclusively owned by MCUmgr, for the time of download
+    session, and may change between requests or even be removed.
+    """
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_DOWNLOAD_UPLOAD
+    _Response = FileUploadResponse
+
+    off: int
+    """Offset to start/continue writing to."""
+    data: bytes
+    """Data to write to the file."""
+    name: str
+    """Name of the file to upload."""
+    len: int | None = None
+    """The length of the file, only mandatory if “off” is 0."""
+
+
+class FileStatusResponse(message.ReadResponse, frozen=True):
+    """Success response to a file status request."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_STATUS
+
+    len: int
+
+
+class FileStatusRequest(message.ReadRequest, _FileGroupBase, frozen=True):
+    """Retrieve status of an existing file from specified path of a target device."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_STATUS
+    _Response = FileStatusResponse
+
+    name: str
+
+
+class FileHashChecksumResponse(message.ReadResponse, frozen=True):
+    """Success response to a file hash/checksum request."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_HASH_CHECKSUM
+
+    type: Literal["crc32", "sha256"]
+    len: int
+    """Length of input data used to generate hash/checksum."""
+    output: int | bytes
+    """Output hash/checksum, depending on the type requested."""
+    off: int | None = None
+    """Only present if not 0."""
+
+
+class FileHashChecksumRequest(message.ReadRequest, _FileGroupBase, frozen=True):
+    """Generate a hash/checksum of an existing file at a specified path on a target device.
+
+    Note that kernel heap memory is required for buffers to be allocated for
+    this to function, and large stack memory buffers are required for generation
+    of the output hash/checksum. Requires `CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH` to
+    be enabled for the base functionality, supported hash/checksum are opt-in
+    with `CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32` or
+    `CONFIG_MCUMGR_GRP_FS_HASH_SHA256`.
+    """
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_HASH_CHECKSUM
+    _Response = FileHashChecksumResponse
+
+    name: str
+    """Absolute path to the file to generate hash/checksum for."""
+    type: Literal["crc32", "sha256"] | None = None
+    """Type of hash/checksum to generate, if not provided, default is used."""
+    off: int | None = None
+    """Offset to start hash/checksum generation from, default 0."""
+    len: int | None = None
+    """Maximum length of the file to generate hash/checksum for, default is entire file."""
+
+
+class HashChecksumFormat(IntEnum):
+    """Format that the hash/checksum returns where 0 is for numerical and 1 is for byte array."""
+
+    NUMERICAL = 0
+    BYTE_ARRAY = 1
+
+
+class HashChecksumType(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
+    """Hash and checksum type supported by the device."""
+
+    format: HashChecksumFormat
+    """Format that the hash/checksum returns where 0 is for numerical and 1 is for byte array."""
+    size: int
+    """Size of the hash/checksum in bytes."""
+
+
+class SupportedFileHashChecksumTypesResponse(message.ReadResponse, frozen=True):
+    """Success response to a supported file hash/checksum types request."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.SUPPORTED_FILE_HASH_CHECKSUM_TYPES
+
+    types: dict[Literal["crc32", "sha256"], HashChecksumType]
+    """The map of supported hash/checksum types."""
+
+
+class SupportedFileHashChecksumTypesRequest(message.ReadRequest, _FileGroupBase, frozen=True):
+    """List the hash and checksum types are available on a device.
+
+    Requires Kconfig `CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD` to be enabled.
+    """
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.SUPPORTED_FILE_HASH_CHECKSUM_TYPES
+    _Response = SupportedFileHashChecksumTypesResponse
+
+
+class FileCloseResponse(message.WriteResponse, frozen=True):
+    """Success response to a file close request."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_CLOSE
+
+
+class FileCloseRequest(message.WriteRequest, _FileGroupBase, frozen=True):
+    """Close all open file handles held by fs_mgmt upload/download requests."""
+
+    _GROUP_ID = header.GroupId.FILE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.FileManagement.FILE_CLOSE
+    _Response = FileCloseResponse

--- a/src/smp/file_management.py
+++ b/src/smp/file_management.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from enum import IntEnum, unique
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+import msgspec
 
 from smp import error, header, message
 
 
-class FileDownloadRequest(message.ReadRequest):
+class FileDownloadRequest(message.ReadRequest, frozen=True):
     """Download contents of an existing file from specified path.
 
     Client applications must keep track of data they have already downloaded and
@@ -34,7 +34,7 @@ class FileDownloadRequest(message.ReadRequest):
     """Name of the file to download."""
 
 
-class FileDownloadResponse(message.ReadResponse):
+class FileDownloadResponse(message.ReadResponse, frozen=True):
     """Success response to a file download request."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
@@ -48,7 +48,7 @@ class FileDownloadResponse(message.ReadResponse):
     """The length of the file, only mandatory if “off” is 0."""
 
 
-class FileUploadRequest(message.WriteRequest):
+class FileUploadRequest(message.WriteRequest, frozen=True):
     """Upload a file to a specified location.
 
     Command will automatically overwrite existing file or create a new one if it
@@ -79,7 +79,7 @@ class FileUploadRequest(message.WriteRequest):
     """The length of the file, only mandatory if “off” is 0."""
 
 
-class FileUploadResponse(message.WriteResponse):
+class FileUploadResponse(message.WriteResponse, frozen=True):
     """Success response to a file upload request."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
@@ -89,7 +89,7 @@ class FileUploadResponse(message.WriteResponse):
     """Offset of the file."""
 
 
-class FileStatusRequest(message.ReadRequest):
+class FileStatusRequest(message.ReadRequest, frozen=True):
     """Retrieve status of an existing file from specified path of a target device."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
@@ -98,7 +98,7 @@ class FileStatusRequest(message.ReadRequest):
     name: str
 
 
-class FileStatusResponse(message.ReadResponse):
+class FileStatusResponse(message.ReadResponse, frozen=True):
     """Success response to a file status request."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
@@ -107,7 +107,7 @@ class FileStatusResponse(message.ReadResponse):
     len: int
 
 
-class FileHashChecksumRequest(message.ReadRequest):
+class FileHashChecksumRequest(message.ReadRequest, frozen=True):
     """Generate a hash/checksum of an existing file at a specified path on a target device.
 
     Note that kernel heap memory is required for buffers to be allocated for
@@ -131,22 +131,22 @@ class FileHashChecksumRequest(message.ReadRequest):
     """Maximum length of the file to generate hash/checksum for, default is entire file."""
 
 
-class FileHashChecksumResponse(message.ReadResponse):
+class FileHashChecksumResponse(message.ReadResponse, frozen=True):
     """Success response to a file hash/checksum request."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
     _COMMAND_ID = header.CommandId.FileManagement.FILE_HASH_CHECKSUM
 
     type: Literal["crc32", "sha256"]
-    off: int | None = None
-    """Only present if not 0."""
     len: int
     """Length of input data used to generate hash/checksum."""
     output: int | bytes
     """Output hash/checksum, depending on the type requested."""
+    off: int | None = None
+    """Only present if not 0."""
 
 
-class SupportedFileHashChecksumTypesRequest(message.ReadRequest):
+class SupportedFileHashChecksumTypesRequest(message.ReadRequest, frozen=True):
     """List the hash and checksum types are available on a device.
 
     Requires Kconfig `CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD` to be enabled.
@@ -163,10 +163,8 @@ class HashChecksumFormat(IntEnum):
     BYTE_ARRAY = 1
 
 
-class HashChecksumType(BaseModel):
+class HashChecksumType(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
     """Hash and checksum type supported by the device."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
 
     format: HashChecksumFormat
     """Format that the hash/checksum returns where 0 is for numerical and 1 is for byte array."""
@@ -174,7 +172,7 @@ class HashChecksumType(BaseModel):
     """Size of the hash/checksum in bytes."""
 
 
-class SupportedFileHashChecksumTypesResponse(message.ReadResponse):
+class SupportedFileHashChecksumTypesResponse(message.ReadResponse, frozen=True):
     """Success response to a supported file hash/checksum types request."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
@@ -184,14 +182,14 @@ class SupportedFileHashChecksumTypesResponse(message.ReadResponse):
     """The map of supported hash/checksum types."""
 
 
-class FileCloseRequest(message.WriteRequest):
+class FileCloseRequest(message.WriteRequest, frozen=True):
     """Close all open file handles held by fs_mgmt upload/download requests."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
     _COMMAND_ID = header.CommandId.FileManagement.FILE_CLOSE
 
 
-class FileCloseResponse(message.WriteResponse):
+class FileCloseResponse(message.WriteResponse, frozen=True):
     """Success response to a file close request."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
@@ -258,13 +256,13 @@ class FS_MGMT_ERR(IntEnum):
     """The operation cannot be performed because the file is empty with no contents. """
 
 
-class FileSystemManagementErrorV1(error.ErrorV1):
+class FileSystemManagementErrorV1(error.ErrorV1, frozen=True):
     """File System Management error response."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT
 
 
-class FileSystemManagementErrorV2(error.ErrorV2[FS_MGMT_ERR]):
+class FileSystemManagementErrorV2(error.ErrorV2[FS_MGMT_ERR], frozen=True):
     """File System Management error response."""
 
     _GROUP_ID = header.GroupId.FILE_MANAGEMENT

--- a/src/smp/header.py
+++ b/src/smp/header.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import struct
 from dataclasses import dataclass
 from enum import IntEnum, IntFlag, unique
-from typing import Annotated, ClassVar, TypeAlias
+from typing import ClassVar, TypeAlias, TypeVar
 
-from pydantic import Field
+E = TypeVar("E", bound=IntEnum)
 
 
 class CommandId:
@@ -99,7 +99,19 @@ class UserGroupId(IntEnum):
     INTERCREATE = 64
 
 
-GroupIdField = Annotated[GroupId | UserGroupId | int, Field(union_mode="left_to_right")]
+GroupIdField: TypeAlias = GroupId | UserGroupId | int
+
+
+def resolve_int_enum(value: int, enum: type[E]) -> E | int:
+    try:
+        return enum(value)
+    except ValueError:
+        return value
+
+
+def resolve_group_id(value: int) -> GroupId | UserGroupId | int:
+    resolved = resolve_int_enum(value, GroupId)
+    return resolved if isinstance(resolved, GroupId) else resolve_int_enum(value, UserGroupId)
 
 
 @unique

--- a/src/smp/image_management.py
+++ b/src/smp/image_management.py
@@ -31,215 +31,6 @@ import msgspec
 from smp import error, header, message
 
 
-class ImageState(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
-    """The state of an image in a slot."""
-
-    slot: int
-    """Slot number within “image”.
-
-    Each image has two slots:
-    - primary (running one) = 0
-    - secondary (for DFU dual-bank purposes) = 1.
-    """
-    version: str
-    """Version of the image."""
-    image: int | None = None
-    """Semi-optional image number.
-
-    The field is not required when only one image is supported by the running
-    application.
-    """
-    hash: bytes | None = None
-    """SHA256 hash of the image header and body.
-
-    Note that this will not be the same as the SHA256 of the whole file, it is
-    the field in the MCUboot TLV section that contains a hash of the data which
-    is used for signature verification purposes. This field is optional but only
-    optional when using MCUboot's serial recovery feature with one pair of image
-    slots, `CONFIG_BOOT_SERIAL_IMG_GRP_HASH` can be disabled to remove
-    support for hashes in this configuration. SMP server in applications must
-    support sending hashes.
-    """
-    bootable: bool | None = None
-    """True if image has bootable flag set.
-
-    This field does not have to be present if false.
-    """
-    pending: bool | None = None
-    """True if image is set for next swap.
-
-    This field does not have to be present if false.
-    """
-    confirmed: bool | None = None
-    """True if image has been confirmed.
-
-    This field does not have to be present if false.
-    """
-    active: bool | None = None
-    """True if image is currently active application
-
-    This field does not have to be present if false.
-    """
-    permanent: bool | None = None
-    """True if image is to stay in primary slot after the next boot.
-
-    This does not have to be present if false.
-    """
-
-
-class ImageStatesReadRequest(message.ReadRequest, frozen=True):
-    """Obtain list of images with their current state."""
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.STATE
-
-
-class ImageStatesReadResponse(message.ReadResponse, frozen=True):
-    """Response to an image state request."""
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.STATE
-
-    images: list[ImageState]
-    """List of images with their current state."""
-    splitStatus: int | None = None
-    """States whether loader of split image is compatible with application part.
-
-    This is unused by Zephyr.
-    """
-
-
-class ImageStatesWriteRequest(message.WriteRequest, frozen=True):
-    """Set the state of an image.
-
-    If “confirm” is false or not provided, an image with the “hash” will be set
-    for test, which means that it will not be marked as permanent and upon hard
-    reset the previous application will be restored to the primary slot. In case
-    when “confirm” is true, the “hash” is optional as the currently running
-    application will be assumed as target for confirmation.
-    """
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.STATE
-
-    hash: bytes | None = None
-    """SHA256 hash of the image header and body."""
-    confirm: bool = False
-    """Confirm the image given by hash.
-
-    CAUTION: it is dangerous to confirm the image before it has been booted!
-
-    Setting this to true will mark the image as confirmed before it has been
-    booted, which can brick the device.  Zephyr provides hooks for confirming
-    the image from within the application, so this is not necessary for normal
-    operation.
-    """
-
-
-class ImageStatesWriteResponse(ImageStatesReadResponse, frozen=True):
-    """Success response to an image state write request."""
-
-
-class ImageUploadWriteRequest(message.WriteRequest, frozen=True):
-    """Upload an image to the device.
-
-    The image is uploaded in chunks, with each chunk being sent in a separate
-    request. The first request must include the image's length and image number.
-    """
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.UPLOAD
-
-    off: int
-    """The offset of the data chunk in this request."""
-    data: bytes
-    """The data chunk to write."""
-    image: int | None = None
-    """Image number.
-
-    It does not have to appear in request at all, in which case it is assumed to
-    be 0. Should only be present when `off` is 0.
-    """
-    len: int | None = None
-    """The length of the image.
-
-    Required when `off` is 0, otherwise ignored.
-    """
-    sha: bytes | None = None
-    """SHA256 hash of the image.
-
-    This is used to identify an upload session (e.g. to allow to continue
-    a broken session), and for image verification purposes. This must be a full
-    SHA256 hash of the whole image being uploaded, or not included if the hash
-    is not available (in which case, upload session continuation and image
-    verification functionality will be unavailable). Should only be present when
-    “off” is 0.
-    """
-    upgrade: bool | None = None
-    """Optional flag that states that only upgrade should be allowed.
-
-    If the version of uploaded software is not higher then already on a device,
-    the image upload will be rejected. Zephyr compares major, minor and
-    revision (x.y.z) by default unless `CONFIG_MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER`
-    is set, whereby it will compare build numbers too. Should only be present
-    when “off” is 0.
-    """
-
-
-class ImageUploadWriteResponse(message.WriteResponse, frozen=True):
-    """Success response to an image upload request."""
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.UPLOAD
-
-    off: int | None = None
-    """The portion of the upload that has been completed, in 8-bit bytes.
-
-    This is the offset of the next byte to be written. If the offset is equal to
-    the length of the image, the upload is complete.
-    """
-
-    match: bool | None = None
-    """Indicates if the uploaded data successfully matches the provided SHA256.
-
-    Only sent in the final packet if CONFIG_IMG_ENABLE_IMAGE_CHECK is enabled.
-    """
-
-    rc: int | None = None
-    """Legacy field that contains a return code; possibly `MGMT_ERR`.
-
-    This field may be present on old SMP server implementations or new SMP
-    server implementations that have set
-    `CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR=y` for backwards compatibility with
-    old SMP clients.
-
-    Note that we are not validating this field because we don't necessarily
-    trust the server to send us valid values. If this value is present, then it
-    indicates use of an SMP server that is out of spec and interpretation of the
-    value should be done with reference to that server's source code, rather
-    that the SMP specification.
-
-    Zephyr source code reference: https://github.com/zephyrproject-rtos/zephyr/blob/91a1e706535b2f99433280513c5bc66dfb918506/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c#L397-L400
-    """
-
-
-class ImageEraseRequest(message.WriteRequest, frozen=True):
-    """Erase an image from a slot."""
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.ERASE
-
-    slot: int | None = None
-    """The slot to erase. If not provided, slot 1 will be erased."""
-
-
-class ImageEraseResponse(message.WriteResponse, frozen=True):
-    """Success response to an image erase request."""
-
-    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ImageManagement.ERASE
-
-
 @unique
 class IMG_MGMT_ERR(IntEnum):
     """Image management error codes."""
@@ -357,3 +148,221 @@ class ImageManagementErrorV2(error.ErrorV2[IMG_MGMT_ERR], frozen=True):
     """Image Management error response."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+
+
+class _ImageGroupBase:
+    _ErrorV1 = ImageManagementErrorV1
+    _ErrorV2 = ImageManagementErrorV2
+
+
+class ImageState(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
+    """The state of an image in a slot."""
+
+    slot: int
+    """Slot number within “image”.
+
+    Each image has two slots:
+    - primary (running one) = 0
+    - secondary (for DFU dual-bank purposes) = 1.
+    """
+    version: str
+    """Version of the image."""
+    image: int | None = None
+    """Semi-optional image number.
+
+    The field is not required when only one image is supported by the running
+    application.
+    """
+    hash: bytes | None = None
+    """SHA256 hash of the image header and body.
+
+    Note that this will not be the same as the SHA256 of the whole file, it is
+    the field in the MCUboot TLV section that contains a hash of the data which
+    is used for signature verification purposes. This field is optional but only
+    optional when using MCUboot's serial recovery feature with one pair of image
+    slots, `CONFIG_BOOT_SERIAL_IMG_GRP_HASH` can be disabled to remove
+    support for hashes in this configuration. SMP server in applications must
+    support sending hashes.
+    """
+    bootable: bool | None = None
+    """True if image has bootable flag set.
+
+    This field does not have to be present if false.
+    """
+    pending: bool | None = None
+    """True if image is set for next swap.
+
+    This field does not have to be present if false.
+    """
+    confirmed: bool | None = None
+    """True if image has been confirmed.
+
+    This field does not have to be present if false.
+    """
+    active: bool | None = None
+    """True if image is currently active application
+
+    This field does not have to be present if false.
+    """
+    permanent: bool | None = None
+    """True if image is to stay in primary slot after the next boot.
+
+    This does not have to be present if false.
+    """
+
+
+class ImageStatesReadResponse(message.ReadResponse, frozen=True):
+    """Response to an image state request."""
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.STATE
+
+    images: list[ImageState]
+    """List of images with their current state."""
+    splitStatus: int | None = None
+    """States whether loader of split image is compatible with application part.
+
+    This is unused by Zephyr.
+    """
+
+
+class ImageStatesReadRequest(message.ReadRequest, _ImageGroupBase, frozen=True):
+    """Obtain list of images with their current state."""
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.STATE
+    _Response = ImageStatesReadResponse
+
+
+class ImageStatesWriteResponse(ImageStatesReadResponse, frozen=True):
+    """Success response to an image state write request."""
+
+
+class ImageStatesWriteRequest(message.WriteRequest, _ImageGroupBase, frozen=True):
+    """Set the state of an image.
+
+    If “confirm” is false or not provided, an image with the “hash” will be set
+    for test, which means that it will not be marked as permanent and upon hard
+    reset the previous application will be restored to the primary slot. In case
+    when “confirm” is true, the “hash” is optional as the currently running
+    application will be assumed as target for confirmation.
+    """
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.STATE
+    _Response = ImageStatesWriteResponse
+
+    hash: bytes | None = None
+    """SHA256 hash of the image header and body."""
+    confirm: bool = False
+    """Confirm the image given by hash.
+
+    CAUTION: it is dangerous to confirm the image before it has been booted!
+
+    Setting this to true will mark the image as confirmed before it has been
+    booted, which can brick the device.  Zephyr provides hooks for confirming
+    the image from within the application, so this is not necessary for normal
+    operation.
+    """
+
+
+class ImageUploadWriteResponse(message.WriteResponse, frozen=True):
+    """Success response to an image upload request."""
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.UPLOAD
+
+    off: int | None = None
+    """The portion of the upload that has been completed, in 8-bit bytes.
+
+    This is the offset of the next byte to be written. If the offset is equal to
+    the length of the image, the upload is complete.
+    """
+
+    match: bool | None = None
+    """Indicates if the uploaded data successfully matches the provided SHA256.
+
+    Only sent in the final packet if CONFIG_IMG_ENABLE_IMAGE_CHECK is enabled.
+    """
+
+    rc: int | None = None
+    """Legacy field that contains a return code; possibly `MGMT_ERR`.
+
+    This field may be present on old SMP server implementations or new SMP
+    server implementations that have set
+    `CONFIG_MCUMGR_SMP_LEGACY_RC_BEHAVIOUR=y` for backwards compatibility with
+    old SMP clients.
+
+    Note that we are not validating this field because we don't necessarily
+    trust the server to send us valid values. If this value is present, then it
+    indicates use of an SMP server that is out of spec and interpretation of the
+    value should be done with reference to that server's source code, rather
+    that the SMP specification.
+
+    Zephyr source code reference: https://github.com/zephyrproject-rtos/zephyr/blob/91a1e706535b2f99433280513c5bc66dfb918506/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c#L397-L400
+    """
+
+
+class ImageUploadWriteRequest(message.WriteRequest, _ImageGroupBase, frozen=True):
+    """Upload an image to the device.
+
+    The image is uploaded in chunks, with each chunk being sent in a separate
+    request. The first request must include the image's length and image number.
+    """
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.UPLOAD
+    _Response = ImageUploadWriteResponse
+
+    off: int
+    """The offset of the data chunk in this request."""
+    data: bytes
+    """The data chunk to write."""
+    image: int | None = None
+    """Image number.
+
+    It does not have to appear in request at all, in which case it is assumed to
+    be 0. Should only be present when `off` is 0.
+    """
+    len: int | None = None
+    """The length of the image.
+
+    Required when `off` is 0, otherwise ignored.
+    """
+    sha: bytes | None = None
+    """SHA256 hash of the image.
+
+    This is used to identify an upload session (e.g. to allow to continue
+    a broken session), and for image verification purposes. This must be a full
+    SHA256 hash of the whole image being uploaded, or not included if the hash
+    is not available (in which case, upload session continuation and image
+    verification functionality will be unavailable). Should only be present when
+    “off” is 0.
+    """
+    upgrade: bool | None = None
+    """Optional flag that states that only upgrade should be allowed.
+
+    If the version of uploaded software is not higher then already on a device,
+    the image upload will be rejected. Zephyr compares major, minor and
+    revision (x.y.z) by default unless `CONFIG_MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER`
+    is set, whereby it will compare build numbers too. Should only be present
+    when “off” is 0.
+    """
+
+
+class ImageEraseResponse(message.WriteResponse, frozen=True):
+    """Success response to an image erase request."""
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.ERASE
+
+
+class ImageEraseRequest(message.WriteRequest, _ImageGroupBase, frozen=True):
+    """Erase an image from a slot."""
+
+    _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ImageManagement.ERASE
+    _Response = ImageEraseResponse
+
+    slot: int | None = None
+    """The slot to erase. If not provided, slot 1 will be erased."""

--- a/src/smp/image_management.py
+++ b/src/smp/image_management.py
@@ -25,27 +25,14 @@ follows:
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
+import msgspec
 
 from smp import error, header, message
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
 
-
-class HashBytes(bytes):  # pragma: no cover
-    """Only to print something useful to the `rich` console."""
-
-    def __rich_repr__(self) -> Generator[str, None, None]:
-        yield self.hex().upper()
-
-
-class ImageState(BaseModel):
+class ImageState(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
     """The state of an image in a slot."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, arbitrary_types_allowed=True)
 
     slot: int
     """Slot number within “image”.
@@ -62,7 +49,7 @@ class ImageState(BaseModel):
     The field is not required when only one image is supported by the running
     application.
     """
-    hash: HashBytes | bytes | None = None
+    hash: bytes | None = None
     """SHA256 hash of the image header and body.
 
     Note that this will not be the same as the SHA256 of the whole file, it is
@@ -99,22 +86,15 @@ class ImageState(BaseModel):
     This does not have to be present if false.
     """
 
-    @field_validator("hash")
-    @classmethod
-    def cast_bytes(cls, v: bytes | None, _: ValidationInfo) -> HashBytes | None:
-        if v is None:
-            return None
-        return HashBytes(v)
 
-
-class ImageStatesReadRequest(message.ReadRequest):
+class ImageStatesReadRequest(message.ReadRequest, frozen=True):
     """Obtain list of images with their current state."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
     _COMMAND_ID = header.CommandId.ImageManagement.STATE
 
 
-class ImageStatesReadResponse(message.ReadResponse):
+class ImageStatesReadResponse(message.ReadResponse, frozen=True):
     """Response to an image state request."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
@@ -129,7 +109,7 @@ class ImageStatesReadResponse(message.ReadResponse):
     """
 
 
-class ImageStatesWriteRequest(message.WriteRequest):
+class ImageStatesWriteRequest(message.WriteRequest, frozen=True):
     """Set the state of an image.
 
     If “confirm” is false or not provided, an image with the “hash” will be set
@@ -156,11 +136,11 @@ class ImageStatesWriteRequest(message.WriteRequest):
     """
 
 
-class ImageStatesWriteResponse(ImageStatesReadResponse):
+class ImageStatesWriteResponse(ImageStatesReadResponse, frozen=True):
     """Success response to an image state write request."""
 
 
-class ImageUploadWriteRequest(message.WriteRequest):
+class ImageUploadWriteRequest(message.WriteRequest, frozen=True):
     """Upload an image to the device.
 
     The image is uploaded in chunks, with each chunk being sent in a separate
@@ -206,7 +186,7 @@ class ImageUploadWriteRequest(message.WriteRequest):
     """
 
 
-class ImageUploadWriteResponse(message.WriteResponse):
+class ImageUploadWriteResponse(message.WriteResponse, frozen=True):
     """Success response to an image upload request."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
@@ -243,7 +223,7 @@ class ImageUploadWriteResponse(message.WriteResponse):
     """
 
 
-class ImageEraseRequest(message.WriteRequest):
+class ImageEraseRequest(message.WriteRequest, frozen=True):
     """Erase an image from a slot."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
@@ -253,7 +233,7 @@ class ImageEraseRequest(message.WriteRequest):
     """The slot to erase. If not provided, slot 1 will be erased."""
 
 
-class ImageEraseResponse(message.WriteResponse):
+class ImageEraseResponse(message.WriteResponse, frozen=True):
     """Success response to an image erase request."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
@@ -367,13 +347,13 @@ class IMG_MGMT_ERR(IntEnum):
     """Setting test to active slot is not allowed"""
 
 
-class ImageManagementErrorV1(error.ErrorV1):
+class ImageManagementErrorV1(error.ErrorV1, frozen=True):
     """Image Management error response."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT
 
 
-class ImageManagementErrorV2(error.ErrorV2[IMG_MGMT_ERR]):
+class ImageManagementErrorV2(error.ErrorV2[IMG_MGMT_ERR], frozen=True):
     """Image Management error response."""
 
     _GROUP_ID = header.GroupId.IMAGE_MANAGEMENT

--- a/src/smp/message.py
+++ b/src/smp/message.py
@@ -1,30 +1,27 @@
-"""The Simple Management Protocol (SMP) Message base class."""
+"""The Simple Management Protocol (SMP) message base classes.
+
+An SMP message is a `Frame`: an SMP `Header` and its CBOR payload `Data`.
+"""
 
 from __future__ import annotations
 
 import itertools
-import logging
-from abc import ABC
 from enum import IntEnum, unique
-from typing import ClassVar, TypeVar, cast
+from typing import Any, ClassVar, Generic, TypeVar
 
-import cbor2
-from pydantic import BaseModel, ConfigDict
+import msgspec
+import msgspec_cbor
 
 from smp import header as smpheader
 from smp.exceptions import SMPMalformed, SMPMismatchedGroupId
 
-T = TypeVar("T", bound='_MessageBase')
-
-
 _counter = itertools.count()
-logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound="Data")
 
 
-class _MessageBase(ABC, BaseModel):
-    """The base class for SMP messages."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
+class Data(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
+    """The CBOR payload of an SMP `Frame`."""
 
     _OP: ClassVar[smpheader.OP]
     _FLAGS: ClassVar[smpheader.Flag] = smpheader.Flag(0)
@@ -38,137 +35,92 @@ class _MessageBase(ABC, BaseModel):
         | smpheader.CommandId.FileManagement
     ]
 
-    # This is is a dummy header that will be replaced in model_post_init
-    header: smpheader.Header = None  # type: ignore
-    version: smpheader.Version = smpheader.Version.V2
-    sequence: int = None  # type: ignore
-    smp_data: bytes = None  # type: ignore
-
     def __bytes__(self) -> bytes:
-        return self.smp_data
+        return msgspec_cbor.encode(self, order="canonical")
 
-    @property
-    def BYTES(self) -> bytes:
-        return self.smp_data
-
-    @classmethod
-    def loads(cls: type[T], data: bytes) -> T:
-        """Deserialize the SMP message."""
-        message = cls(
-            header=smpheader.Header.loads(data[: smpheader.Header.SIZE]),
-            **cast("dict", cbor2.loads(data[smpheader.Header.SIZE :])),
-            smp_data=data,
+    def to_frame(
+        self: T,
+        *,
+        version: smpheader.Version = smpheader.Version.V2,
+        flags: smpheader.Flag | None = None,
+        sequence: int | None = None,
+    ) -> Frame[T]:
+        """Wrap this `Data` in a `Frame`, synthesizing the SMP `Header`."""
+        payload = bytes(self)
+        return Frame(
+            smpheader.Header(
+                op=self._OP,
+                version=version,
+                flags=smpheader.Flag(self._FLAGS if flags is None else flags),
+                length=len(payload),
+                group_id=self._GROUP_ID,
+                sequence=next(_counter) % 0x100 if sequence is None else sequence,
+                command_id=self._COMMAND_ID,
+            ),
+            self,
         )
-        if message.header is None:  # pragma: no cover
-            raise ValueError
-        if message.header.group_id != cls._GROUP_ID:  # pragma: no cover
-            raise SMPMismatchedGroupId(
-                f"{cls.__name__} has {cls._GROUP_ID}, header has {message.header.group_id}"
-            )
-        return message
 
     @classmethod
-    def load(cls: type[T], header: smpheader.Header, data: dict) -> T:
-        """Load an SMP header and CBOR dict."""
-        if header.group_id != cls._GROUP_ID:  # pragma: no cover
+    def _validate_mapping(cls, data: dict[str, Any]) -> None:
+        fields = msgspec.structs.fields(cls)
+        known = frozenset(f.encode_name for f in fields)
+        for key in data:
+            if key not in known:
+                raise msgspec.ValidationError(f"Object contains unknown field `{key}`")
+        for field in fields:
+            if field.required and field.encode_name not in data:
+                raise msgspec.ValidationError(
+                    f"Object missing required field `{field.encode_name}`"
+                )
+
+    @classmethod
+    def _convert_mapping(cls: type[T], data: dict[str, Any]) -> T:
+        return msgspec.convert(data, type=cls)
+
+    @classmethod
+    def _decode_payload(cls: type[T], payload: bytes) -> T:
+        # Direct decode unless a subclass overrides _convert_mapping to discriminate
+        # an int-like union or a bare dynamic map that msgspec cannot decode directly.
+        if cls._convert_mapping.__func__ is Data._convert_mapping.__func__:  # type: ignore[attr-defined]
+            return msgspec_cbor.decode(payload, type=cls)
+        return cls._convert_mapping(msgspec_cbor.decode(payload, type=dict))
+
+    @classmethod
+    def loads(cls: type[T], frame: bytes) -> Frame[T]:
+        """Deserialize an SMP `Frame` (header followed by CBOR payload)."""
+        header = smpheader.Header.loads(frame[: smpheader.Header.SIZE])
+        if header.length != len(frame) - smpheader.Header.SIZE:
+            raise SMPMalformed(
+                f"header.length {header.length} != payload length "
+                f"{len(frame) - smpheader.Header.SIZE}"
+            )
+        if header.group_id != cls._GROUP_ID:
             raise SMPMismatchedGroupId(
                 f"{cls.__name__} has {cls._GROUP_ID}, header has {header.group_id}"
             )
-        return cls(header=header, **data)
+        return Frame(header, cls._decode_payload(frame[smpheader.Header.SIZE :]))
 
-    def model_post_init(self, _: None) -> None:
-        data_bytes = cbor2.dumps(
-            self.model_dump(
-                exclude_unset=True,
-                exclude={'header', 'version', 'sequence', 'smp_data'},
-                exclude_none=True,
-            ),
-            canonical=True,
-        )
-        if self.header is None:  # create the header
-            object.__setattr__(
-                self,
-                'header',
-                smpheader.Header(
-                    op=self._OP,
-                    version=self.version,
-                    flags=smpheader.Flag(self._FLAGS),
-                    length=len(data_bytes),
-                    group_id=self._GROUP_ID,
-                    sequence=next(_counter) % 0xFF if self.sequence is None else self.sequence,
-                    command_id=self._COMMAND_ID,
-                ),
+    @classmethod
+    def load(cls: type[T], header: smpheader.Header, data: dict[str, Any]) -> Frame[T]:
+        """Build a `Frame` from an SMP header and a decoded CBOR mapping."""
+        if header.group_id != cls._GROUP_ID:
+            raise SMPMismatchedGroupId(
+                f"{cls.__name__} has {cls._GROUP_ID}, header has {header.group_id}"
             )
-            object.__setattr__(self, 'sequence', self.header.sequence)
-        else:  # validate the header and update version & sequence
-            if self.smp_data is None and self.header.length != len(data_bytes):
-                raise SMPMalformed(
-                    f"header.length {self.header.length} != len(data_bytes) {len(data_bytes)}"
-                )
-            if self.sequence is not None:  # pragma: no cover
-                raise ValueError(
-                    f"{self.sequence=} {self.header.sequence=} "
-                    "Do not use the sequence attribute when the header is provided."
-                )
-            object.__setattr__(self, 'sequence', self.header.sequence)
-            if self.version != self.header.version:
-                logger.warning(
-                    f"Overriding {self.version=} with {self.header.version=} "
-                    "from the provided header."
-                )
-            object.__setattr__(self, 'version', self.header.version)
-        if self.smp_data is None:
-            object.__setattr__(self, 'smp_data', bytes(self.header) + data_bytes)
-
-    # # Uncomment this to create a record for a de/serialization regression lock
-    #     self._log_serialized_bytes()
-
-    # def _log_serialized_bytes(self) -> None:
-    #     import json
-    #     import os
-
-    #     from smp.image_management import HashBytes
-
-    #     kwargs = self.model_dump(
-    #         exclude_unset=True,
-    #         exclude={'header', 'version', 'sequence', 'smp_data'},
-    #         exclude_none=True,
-    #     )
-
-    #     message = f"{self.__class__.__module__}.{self.__class__.__qualname__}"
-
-    #     log_dir = "serialization_logs"
-    #     os.makedirs(log_dir, exist_ok=True)
-    #     log_file = os.path.join(log_dir, f"{message}.json")
-
-    #     def convert_bytes(obj: dict) -> dict:
-    #         if isinstance(obj, dict):
-    #             return {k: convert_bytes(v) for k, v in obj.items()}
-    #         elif isinstance(obj, list):
-    #             return [convert_bytes(i) for i in obj]
-    #         elif isinstance(obj, tuple):
-    #             return tuple(convert_bytes(i) for i in obj)
-    #         elif isinstance(obj, bytes) or isinstance(obj, HashBytes):
-    #             return obj.hex()
-    #         else:
-    #             return obj
-
-    #     log_data = {
-    #         "message": message,
-    #         "version": self.version,
-    #         "sequence": self.sequence,
-    #         "kwargs": convert_bytes(kwargs),
-    #         "bytes": self.BYTES.hex(),
-    #     }
-
-    #     try:
-    #         with open(log_file, "a") as f:
-    #             f.write(json.dumps(log_data) + "\n")
-    #     except OSError as e:
-    #         print(f"Failed to write to {log_file}: {e}")
+        return Frame(header, cls._convert_mapping(data))
 
 
-class Request(_MessageBase, ABC):
+class Frame(msgspec.Struct, Generic[T], frozen=True):
+    """An SMP message: an SMP `Header` and its `Data` payload."""
+
+    header: smpheader.Header
+    data: T
+
+    def __bytes__(self) -> bytes:
+        return bytes(self.header) + bytes(self.data)
+
+
+class Request(Data, frozen=True):
     """Base class for SMP Requests."""
 
 
@@ -181,32 +133,32 @@ class ResponseType(IntEnum):
     ERROR_V2 = 2
 
 
-class Response(_MessageBase, ABC):
+class Response(Data, frozen=True):
     """Base class for SMP Responses."""
 
     RESPONSE_TYPE: ClassVar[ResponseType]
 
 
-class ReadRequest(Request, ABC):
+class ReadRequest(Request, frozen=True):
     """A read request from an SMP client to an SMP server."""
 
     _OP = smpheader.OP.READ
 
 
-class ReadResponse(Response, ABC):
+class ReadResponse(Response, frozen=True):
     """A response from an SMP server to an SMP client read request."""
 
     RESPONSE_TYPE = ResponseType.SUCCESS
     _OP = smpheader.OP.READ_RSP
 
 
-class WriteRequest(Request, ABC):
+class WriteRequest(Request, frozen=True):
     """A write request from an SMP client to an SMP server."""
 
     _OP = smpheader.OP.WRITE
 
 
-class WriteResponse(Response, ABC):
+class WriteResponse(Response, frozen=True):
     """A response from an SMP server to an SMP client write request."""
 
     RESPONSE_TYPE = ResponseType.SUCCESS

--- a/src/smp/os_management.py
+++ b/src/smp/os_management.py
@@ -11,14 +11,44 @@ import msgspec_cbor
 from smp import error, header, message
 
 
-class EchoWriteRequest(message.WriteRequest, frozen=True):
-    """Echo back the provided string."""
+@unique
+class OS_MGMT_RET_RC(IntEnum):
+    """OS Management return codes."""
+
+    OK = 0
+    """No error, this is implied if there is no ret value in the response."""
+
+    UNKNOWN = 1
+    """Unknown error occurred."""
+
+    INVALID_FORMAT = 2
+    """The provided format value is not valid."""
+
+    QUERY_YIELDS_NO_ANSWER = 3
+    """Query was not recognized."""
+
+    RTC_NOT_SET = 4
+    """RTC is not set."""
+
+    RTC_COMMAND_FAILED = 5
+    """RTC command failed."""
+
+
+class OSManagementErrorV1(error.ErrorV1, frozen=True):
+    """OS Management error response."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.ECHO
 
-    d: str
-    """String to echo."""
+
+class OSManagementErrorV2(error.ErrorV2[OS_MGMT_RET_RC], frozen=True):
+    """OS Management error response."""
+
+    _GROUP_ID = header.GroupId.OS_MANAGEMENT
+
+
+class _OSGroupBase:
+    _ErrorV1 = OSManagementErrorV1
+    _ErrorV2 = OSManagementErrorV2
 
 
 class EchoWriteResponse(message.WriteResponse, frozen=True):
@@ -29,6 +59,17 @@ class EchoWriteResponse(message.WriteResponse, frozen=True):
 
     r: str
     """Echoed string."""
+
+
+class EchoWriteRequest(message.WriteRequest, _OSGroupBase, frozen=True):
+    """Echo back the provided string."""
+
+    _GROUP_ID = header.GroupId.OS_MANAGEMENT
+    _COMMAND_ID = header.CommandId.OSManagement.ECHO
+    _Response = EchoWriteResponse
+
+    d: str
+    """String to echo."""
 
 
 @unique
@@ -46,7 +87,14 @@ class BootMode(IntEnum):
     """Bootloader boot mode, e.g. serial recovery for MCUboot."""
 
 
-class ResetWriteRequest(message.WriteRequest, frozen=True):
+class ResetWriteResponse(message.WriteResponse, frozen=True):
+    """Success response to a reset request."""
+
+    _GROUP_ID = header.GroupId.OS_MANAGEMENT
+    _COMMAND_ID = header.CommandId.OSManagement.RESET
+
+
+class ResetWriteRequest(message.WriteRequest, _OSGroupBase, frozen=True):
     """Performs reset of system.
 
     The device should issue response before resetting so that the SMP client
@@ -62,6 +110,7 @@ class ResetWriteRequest(message.WriteRequest, frozen=True):
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.RESET
+    _Response = ResetWriteResponse
 
     force: Literal[0, 1] | None = None
     """Force reset.
@@ -100,20 +149,6 @@ class ResetWriteRequest(message.WriteRequest, frozen=True):
             if "boot_mode" in data
             else None,
         )
-
-
-class ResetWriteResponse(message.WriteResponse, frozen=True):
-    """Success response to a reset request."""
-
-    _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.RESET
-
-
-class TaskStatisticsReadRequest(message.ReadRequest, frozen=True):
-    """Request task statistics."""
-
-    _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.TASK_STATS
 
 
 class TaskStatistics(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
@@ -204,11 +239,12 @@ class TaskStatisticsReadResponse(message.ReadResponse, frozen=True):
         return cls(tasks={name: _discriminate_task(t) for name, t in tasks.items()})
 
 
-class MemoryPoolStatisticsReadRequest(message.ReadRequest, frozen=True):
-    """Request memory pool statistics."""
+class TaskStatisticsReadRequest(message.ReadRequest, _OSGroupBase, frozen=True):
+    """Request task statistics."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.MEMORY_POOL_STATS
+    _COMMAND_ID = header.CommandId.OSManagement.TASK_STATS
+    _Response = TaskStatisticsReadResponse
 
 
 class MemoryPoolStatistics(
@@ -243,11 +279,12 @@ class MemoryPoolStatisticsReadResponse(message.ReadResponse, frozen=True):
         return cls(pools=msgspec.convert(data, type=dict[str, MemoryPoolStatistics]))
 
 
-class DateTimeReadRequest(message.ReadRequest, frozen=True):
-    """Request the current date and time."""
+class MemoryPoolStatisticsReadRequest(message.ReadRequest, _OSGroupBase, frozen=True):
+    """Request memory pool statistics."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.DATETIME_STRING
+    _COMMAND_ID = header.CommandId.OSManagement.MEMORY_POOL_STATS
+    _Response = MemoryPoolStatisticsReadResponse
 
 
 class DateTimeReadResponse(message.ReadResponse, frozen=True):
@@ -259,13 +296,12 @@ class DateTimeReadResponse(message.ReadResponse, frozen=True):
     datetime: str
 
 
-class DateTimeWriteRequest(message.WriteRequest, frozen=True):
-    """Set the current date and time."""
+class DateTimeReadRequest(message.ReadRequest, _OSGroupBase, frozen=True):
+    """Request the current date and time."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.DATETIME_STRING
-
-    datetime: str
+    _Response = DateTimeReadResponse
 
 
 class DateTimeWriteResponse(message.WriteResponse, frozen=True):
@@ -275,11 +311,14 @@ class DateTimeWriteResponse(message.WriteResponse, frozen=True):
     _COMMAND_ID = header.CommandId.OSManagement.DATETIME_STRING
 
 
-class MCUMgrParametersReadRequest(message.ReadRequest, frozen=True):
-    """Request MCU Manager parameters."""
+class DateTimeWriteRequest(message.WriteRequest, _OSGroupBase, frozen=True):
+    """Set the current date and time."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.MCUMGR_PARAMETERS
+    _COMMAND_ID = header.CommandId.OSManagement.DATETIME_STRING
+    _Response = DateTimeWriteResponse
+
+    datetime: str
 
 
 class MCUMgrParametersReadResponse(message.ReadResponse, frozen=True):
@@ -294,11 +333,30 @@ class MCUMgrParametersReadResponse(message.ReadResponse, frozen=True):
     """Number of SMP buffers."""
 
 
-class OSApplicationInfoReadRequest(message.ReadRequest, frozen=True):
+class MCUMgrParametersReadRequest(message.ReadRequest, _OSGroupBase, frozen=True):
+    """Request MCU Manager parameters."""
+
+    _GROUP_ID = header.GroupId.OS_MANAGEMENT
+    _COMMAND_ID = header.CommandId.OSManagement.MCUMGR_PARAMETERS
+    _Response = MCUMgrParametersReadResponse
+
+
+class OSApplicationInfoReadResponse(message.ReadResponse, frozen=True):
+    """Success response to an application information request."""
+
+    _GROUP_ID = header.GroupId.OS_MANAGEMENT
+    _COMMAND_ID = header.CommandId.OSManagement.OS_APPLICATION_INFO
+
+    output: str
+    """Text response including requested parameters."""
+
+
+class OSApplicationInfoReadRequest(message.ReadRequest, _OSGroupBase, frozen=True):
     """Request information about the application running on the device."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.OS_APPLICATION_INFO
+    _Response = OSApplicationInfoReadResponse
 
     format: str | None = None
     """Format specifier of returned response.
@@ -319,34 +377,6 @@ class OSApplicationInfoReadRequest(message.ReadRequest, frozen=True):
     * `a` All fields (shorthand for all above options)
 
     If this option is not provided, the `s` Kernel name option will be used.
-    """
-
-
-class OSApplicationInfoReadResponse(message.ReadResponse, frozen=True):
-    """Success response to an application information request."""
-
-    _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.OS_APPLICATION_INFO
-
-    output: str
-    """Text response including requested parameters."""
-
-
-class BootloaderInformationReadRequest(message.ReadRequest, frozen=True):
-    """Request bootloader information."""
-
-    _GROUP_ID = header.GroupId.OS_MANAGEMENT
-    _COMMAND_ID = header.CommandId.OSManagement.BOOTLOADER_INFO
-
-    query: str | None = None
-    """Is string representing query for parameters.
-
-    With no restrictions how the query looks like as processing of query is left
-    for bootloader backend. If there is no query, then response will return string
-    identifying the bootloader.
-
-    MCUboot supports the query string,"mode".  The response to mode is of type
-    `MCUbootMode`.
     """
 
 
@@ -388,36 +418,20 @@ class BootloaderInformationReadResponse(message.ReadResponse, frozen=True):
     be a map, that is dependent on bootloader backend and query."""
 
 
-@unique
-class OS_MGMT_RET_RC(IntEnum):
-    """OS Management return codes."""
-
-    OK = 0
-    """No error, this is implied if there is no ret value in the response."""
-
-    UNKNOWN = 1
-    """Unknown error occurred."""
-
-    INVALID_FORMAT = 2
-    """The provided format value is not valid."""
-
-    QUERY_YIELDS_NO_ANSWER = 3
-    """Query was not recognized."""
-
-    RTC_NOT_SET = 4
-    """RTC is not set."""
-
-    RTC_COMMAND_FAILED = 5
-    """RTC command failed."""
-
-
-class OSManagementErrorV1(error.ErrorV1, frozen=True):
-    """OS Management error response."""
+class BootloaderInformationReadRequest(message.ReadRequest, _OSGroupBase, frozen=True):
+    """Request bootloader information."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
+    _COMMAND_ID = header.CommandId.OSManagement.BOOTLOADER_INFO
+    _Response = BootloaderInformationReadResponse
 
+    query: str | None = None
+    """Is string representing query for parameters.
 
-class OSManagementErrorV2(error.ErrorV2[OS_MGMT_RET_RC], frozen=True):
-    """OS Management error response."""
+    With no restrictions how the query looks like as processing of query is left
+    for bootloader backend. If there is no query, then response will return string
+    identifying the bootloader.
 
-    _GROUP_ID = header.GroupId.OS_MANAGEMENT
+    MCUboot supports the query string,"mode".  The response to mode is of type
+    `MCUbootMode`.
+    """

--- a/src/smp/os_management.py
+++ b/src/smp/os_management.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import Annotated, Any, Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+import msgspec
+import msgspec_cbor
 
 from smp import error, header, message
 
 
-class EchoWriteRequest(message.WriteRequest):
+class EchoWriteRequest(message.WriteRequest, frozen=True):
     """Echo back the provided string."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -20,7 +21,7 @@ class EchoWriteRequest(message.WriteRequest):
     """String to echo."""
 
 
-class EchoWriteResponse(message.WriteResponse):
+class EchoWriteResponse(message.WriteResponse, frozen=True):
     """Success response to an echo request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -45,7 +46,7 @@ class BootMode(IntEnum):
     """Bootloader boot mode, e.g. serial recovery for MCUboot."""
 
 
-class ResetWriteRequest(message.WriteRequest):
+class ResetWriteRequest(message.WriteRequest, frozen=True):
     """Performs reset of system.
 
     The device should issue response before resetting so that the SMP client
@@ -70,9 +71,7 @@ class ResetWriteRequest(message.WriteRequest):
     following map may be sent to force a reset
     """
 
-    boot_mode: BootMode | Annotated[int, Field(ge=0, le=255)] | None = Field(
-        default=None, union_mode="left_to_right"
-    )
+    boot_mode: BootMode | int | None = None
     """Boot mode to set via the retention boot mode module before resetting.
 
     A value of `BootMode.BOOTLOADER` (1) requests, for example, that an MCUboot
@@ -86,25 +85,39 @@ class ResetWriteRequest(message.WriteRequest):
     management group in Zephyr v4.2.0 (zephyrproject-rtos/zephyr#91510).
     """
 
+    def __post_init__(self) -> None:
+        if self.boot_mode is not None and not 0 <= self.boot_mode <= 255:
+            raise ValueError(f"boot_mode {self.boot_mode!r} is not a uint8 (0-255)")
 
-class ResetWriteResponse(message.WriteResponse):
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> ResetWriteRequest:
+        cls._validate_mapping(data)
+        return cls(
+            force=msgspec.convert(data["force"], type=Literal[0, 1]) if "force" in data else None,
+            boot_mode=header.resolve_int_enum(
+                msgspec.convert(data["boot_mode"], type=int), BootMode
+            )
+            if "boot_mode" in data
+            else None,
+        )
+
+
+class ResetWriteResponse(message.WriteResponse, frozen=True):
     """Success response to a reset request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.RESET
 
 
-class TaskStatisticsReadRequest(message.ReadRequest):
+class TaskStatisticsReadRequest(message.ReadRequest, frozen=True):
     """Request task statistics."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.TASK_STATS
 
 
-class TaskStatistics(BaseModel):
+class TaskStatistics(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True):
     """Task statistics."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
 
     prio: int
     """Task priority."""
@@ -132,14 +145,14 @@ class TaskStatistics(BaseModel):
     """Set to 0 by Zephyr."""
 
 
-class TaskStatisticsZephyr(BaseModel):
+class TaskStatisticsZephyr(
+    msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True
+):
     """Task statistics for Zephyr when CONFIG_MCUMGR_GRP_OS_TASKSTAT_ONLY_SUPPORTED_STATS=y.
 
     In this configuration, Zephyr may omit fields that are not supported by the underlying RTOS.
     Only prio, tid, and state are guaranteed to be present.
     """
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
 
     prio: int
     """Task priority."""
@@ -167,7 +180,15 @@ class TaskStatisticsZephyr(BaseModel):
     """Set to 0 by Zephyr."""
 
 
-class TaskStatisticsReadResponse(message.ReadResponse):
+def _discriminate_task(task: dict[str, Any]) -> TaskStatistics | TaskStatisticsZephyr:
+    # No wire tag; try the full struct first, fall back to the Zephyr subset.
+    try:
+        return msgspec.convert(task, type=TaskStatistics)
+    except msgspec.ValidationError:
+        return msgspec.convert(task, type=TaskStatisticsZephyr)
+
+
+class TaskStatisticsReadResponse(message.ReadResponse, frozen=True):
     """Task statistics response."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -176,18 +197,24 @@ class TaskStatisticsReadResponse(message.ReadResponse):
     tasks: dict[str, TaskStatistics | TaskStatisticsZephyr]
     """Task statistics map."""
 
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> TaskStatisticsReadResponse:
+        cls._validate_mapping(data)
+        tasks = msgspec.convert(data["tasks"], type=dict[str, dict[str, Any]])
+        return cls(tasks={name: _discriminate_task(t) for name, t in tasks.items()})
 
-class MemoryPoolStatisticsReadRequest(message.ReadRequest):
+
+class MemoryPoolStatisticsReadRequest(message.ReadRequest, frozen=True):
     """Request memory pool statistics."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.MEMORY_POOL_STATS
 
 
-class MemoryPoolStatistics(BaseModel):
+class MemoryPoolStatistics(
+    msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True
+):
     """Memory pool statistics."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
 
     blksize: int
     """Size of the memory block in the pool."""
@@ -199,23 +226,31 @@ class MemoryPoolStatistics(BaseModel):
     """Lowest number of free blocks the pool reached during run-time."""
 
 
-class MemoryPoolStatisticsReadResponse(message.ReadResponse):
+class MemoryPoolStatisticsReadResponse(message.ReadResponse, frozen=True):
     """The memory pools are accessed by name."""
-
-    model_config = ConfigDict(extra="allow", frozen=True)
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.MEMORY_POOL_STATS
 
+    pools: dict[str, MemoryPoolStatistics]
+    """Memory pool statistics keyed by pool name."""
 
-class DateTimeReadRequest(message.ReadRequest):
+    def __bytes__(self) -> bytes:
+        return msgspec_cbor.encode(self.pools, order="canonical")
+
+    @classmethod
+    def _convert_mapping(cls, data: dict[str, Any]) -> MemoryPoolStatisticsReadResponse:
+        return cls(pools=msgspec.convert(data, type=dict[str, MemoryPoolStatistics]))
+
+
+class DateTimeReadRequest(message.ReadRequest, frozen=True):
     """Request the current date and time."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.DATETIME_STRING
 
 
-class DateTimeReadResponse(message.ReadResponse):
+class DateTimeReadResponse(message.ReadResponse, frozen=True):
     """Response to a date and time request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -224,7 +259,7 @@ class DateTimeReadResponse(message.ReadResponse):
     datetime: str
 
 
-class DateTimeWriteRequest(message.WriteRequest):
+class DateTimeWriteRequest(message.WriteRequest, frozen=True):
     """Set the current date and time."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -233,21 +268,21 @@ class DateTimeWriteRequest(message.WriteRequest):
     datetime: str
 
 
-class DateTimeWriteResponse(message.WriteResponse):
+class DateTimeWriteResponse(message.WriteResponse, frozen=True):
     """Success response to a date and time request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.DATETIME_STRING
 
 
-class MCUMgrParametersReadRequest(message.ReadRequest):
+class MCUMgrParametersReadRequest(message.ReadRequest, frozen=True):
     """Request MCU Manager parameters."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
     _COMMAND_ID = header.CommandId.OSManagement.MCUMGR_PARAMETERS
 
 
-class MCUMgrParametersReadResponse(message.ReadResponse):
+class MCUMgrParametersReadResponse(message.ReadResponse, frozen=True):
     """Success response to a MCU Manager parameters request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -259,7 +294,7 @@ class MCUMgrParametersReadResponse(message.ReadResponse):
     """Number of SMP buffers."""
 
 
-class OSApplicationInfoReadRequest(message.ReadRequest):
+class OSApplicationInfoReadRequest(message.ReadRequest, frozen=True):
     """Request information about the application running on the device."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -287,7 +322,7 @@ class OSApplicationInfoReadRequest(message.ReadRequest):
     """
 
 
-class OSApplicationInfoReadResponse(message.ReadResponse):
+class OSApplicationInfoReadResponse(message.ReadResponse, frozen=True):
     """Success response to an application information request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -297,7 +332,7 @@ class OSApplicationInfoReadResponse(message.ReadResponse):
     """Text response including requested parameters."""
 
 
-class BootloaderInformationReadRequest(message.ReadRequest):
+class BootloaderInformationReadRequest(message.ReadRequest, frozen=True):
     """Request bootloader information."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -327,16 +362,16 @@ class MCUbootMode(IntEnum):
     RAM_LOADER = 6
 
 
-class MCUbootModeQueryResponse(BaseModel):
+class MCUbootModeQueryResponse(
+    msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_fields=True
+):
     """Response to a MCUboot mode query."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
     mode: MCUbootMode
-    no_downgrade: bool | None = Field(alias="no-downgrade", default=None)
+    no_downgrade: bool | None = msgspec.field(name="no-downgrade", default=None)
 
 
-class BootloaderInformationReadResponse(message.ReadResponse):
+class BootloaderInformationReadResponse(message.ReadResponse, frozen=True):
     """Success response to a bootloader information request."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
@@ -344,7 +379,7 @@ class BootloaderInformationReadResponse(message.ReadResponse):
 
     bootloader: str
     """String identifying the bootloader.  For MCUboot it will be "MCUboot"."""
-    response: MCUbootModeQueryResponse | Any | None = None
+    response: MCUbootModeQueryResponse | None = None
     """Response to “query”.
 
     This is optional and may be left out in case when query yields no response,
@@ -376,13 +411,13 @@ class OS_MGMT_RET_RC(IntEnum):
     """RTC command failed."""
 
 
-class OSManagementErrorV1(error.ErrorV1):
+class OSManagementErrorV1(error.ErrorV1, frozen=True):
     """OS Management error response."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT
 
 
-class OSManagementErrorV2(error.ErrorV2[OS_MGMT_RET_RC]):
+class OSManagementErrorV2(error.ErrorV2[OS_MGMT_RET_RC], frozen=True):
     """OS Management error response."""
 
     _GROUP_ID = header.GroupId.OS_MANAGEMENT

--- a/src/smp/settings_management.py
+++ b/src/smp/settings_management.py
@@ -9,124 +9,6 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class ReadSettingRequest(smpmsg.ReadRequest, frozen=True):
-    """Read setting."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
-
-    name: str
-    """The name of the setting to read."""
-
-    max_size: int | None = None
-    """The maximum size of the data to read."""
-
-
-class ReadSettingResponse(smpmsg.ReadResponse, frozen=True):
-    """Read setting success response."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
-
-    val: bytes
-    """Binary string of the returned data.
-
-    Note that the underlying data type cannot be specified through this and must
-    be known by the client.
-    """
-
-    max_size: int | None = None
-    """The SMP server supports a smaller size than requested.
-
-    Will be set if the maximum supported data size is smaller than the maximum
-    requested data size, and contains the maximum data size which the device
-    supports, equivalent to `CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN`.
-    """
-
-
-class WriteSettingRequest(smpmsg.WriteRequest, frozen=True):
-    """Write setting."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
-
-    name: str
-    """The name of the setting to write."""
-
-    val: bytes
-    """Binary data to write."""
-
-
-class WriteSettingResponse(smpmsg.WriteResponse, frozen=True):
-    """Write setting success response."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
-
-
-class DeleteSettingRequest(smpmsg.WriteRequest, frozen=True):
-    """Delete setting."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.DELETE_SETTING
-
-    name: str
-    """The name of the setting to delete."""
-
-
-class DeleteSettingResponse(smpmsg.WriteResponse, frozen=True):
-    """Delete setting success response."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.DELETE_SETTING
-
-
-class CommitSettingsRequest(smpmsg.WriteRequest, frozen=True):
-    """Commit pending settings.
-
-    Commit settings command allows committing all settings that have been set
-    but not yet applied on a device.
-    """
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS
-
-
-class CommitSettingsResponse(smpmsg.WriteResponse, frozen=True):
-    """Commit pending settings success response."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS
-
-
-class LoadSettingsRequest(smpmsg.ReadRequest, frozen=True):
-    """Load settings from persistent storage."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
-
-
-class LoadSettingsResponse(smpmsg.ReadResponse, frozen=True):
-    """Load settings from persistent storage success response."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
-
-
-class SaveSettingsRequest(smpmsg.WriteRequest, frozen=True):
-    """Save settings to persistent storage."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
-
-
-class SaveSettingsResponse(smpmsg.WriteResponse, frozen=True):
-    """Save settings to persistent storage success response."""
-
-    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
-
-
 @unique
 class SETTINGS_MGMT_ERR(IntEnum):
     """Return codes for the settings management group."""
@@ -166,3 +48,132 @@ class SettingsManagementErrorV2(smperr.ErrorV2[SETTINGS_MGMT_ERR], frozen=True):
     """Error response to a settings management command."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+
+
+class _SettingsGroupBase:
+    _ErrorV1 = SettingsManagementErrorV1
+    _ErrorV2 = SettingsManagementErrorV2
+
+
+class ReadSettingResponse(smpmsg.ReadResponse, frozen=True):
+    """Read setting success response."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
+
+    val: bytes
+    """Binary string of the returned data.
+
+    Note that the underlying data type cannot be specified through this and must
+    be known by the client.
+    """
+
+    max_size: int | None = None
+    """The SMP server supports a smaller size than requested.
+
+    Will be set if the maximum supported data size is smaller than the maximum
+    requested data size, and contains the maximum data size which the device
+    supports, equivalent to `CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN`.
+    """
+
+
+class ReadSettingRequest(smpmsg.ReadRequest, _SettingsGroupBase, frozen=True):
+    """Read setting."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
+    _Response = ReadSettingResponse
+
+    name: str
+    """The name of the setting to read."""
+
+    max_size: int | None = None
+    """The maximum size of the data to read."""
+
+
+class WriteSettingResponse(smpmsg.WriteResponse, frozen=True):
+    """Write setting success response."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
+
+
+class WriteSettingRequest(smpmsg.WriteRequest, _SettingsGroupBase, frozen=True):
+    """Write setting."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
+    _Response = WriteSettingResponse
+
+    name: str
+    """The name of the setting to write."""
+
+    val: bytes
+    """Binary data to write."""
+
+
+class DeleteSettingResponse(smpmsg.WriteResponse, frozen=True):
+    """Delete setting success response."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.DELETE_SETTING
+
+
+class DeleteSettingRequest(smpmsg.WriteRequest, _SettingsGroupBase, frozen=True):
+    """Delete setting."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.DELETE_SETTING
+    _Response = DeleteSettingResponse
+
+    name: str
+    """The name of the setting to delete."""
+
+
+class CommitSettingsResponse(smpmsg.WriteResponse, frozen=True):
+    """Commit pending settings success response."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS
+
+
+class CommitSettingsRequest(smpmsg.WriteRequest, _SettingsGroupBase, frozen=True):
+    """Commit pending settings.
+
+    Commit settings command allows committing all settings that have been set
+    but not yet applied on a device.
+    """
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS
+    _Response = CommitSettingsResponse
+
+
+class LoadSettingsResponse(smpmsg.ReadResponse, frozen=True):
+    """Load settings from persistent storage success response."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
+
+
+class LoadSettingsRequest(smpmsg.ReadRequest, _SettingsGroupBase, frozen=True):
+    """Load settings from persistent storage."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
+    _Response = LoadSettingsResponse
+
+
+class SaveSettingsResponse(smpmsg.WriteResponse, frozen=True):
+    """Save settings to persistent storage success response."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
+
+
+class SaveSettingsRequest(smpmsg.WriteRequest, _SettingsGroupBase, frozen=True):
+    """Save settings to persistent storage."""
+
+    _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
+    _Response = SaveSettingsResponse

--- a/src/smp/settings_management.py
+++ b/src/smp/settings_management.py
@@ -9,7 +9,7 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class ReadSettingRequest(smpmsg.ReadRequest):
+class ReadSettingRequest(smpmsg.ReadRequest, frozen=True):
     """Read setting."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
@@ -22,7 +22,7 @@ class ReadSettingRequest(smpmsg.ReadRequest):
     """The maximum size of the data to read."""
 
 
-class ReadSettingResponse(smpmsg.ReadResponse):
+class ReadSettingResponse(smpmsg.ReadResponse, frozen=True):
     """Read setting success response."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
@@ -44,7 +44,7 @@ class ReadSettingResponse(smpmsg.ReadResponse):
     """
 
 
-class WriteSettingRequest(smpmsg.WriteRequest):
+class WriteSettingRequest(smpmsg.WriteRequest, frozen=True):
     """Write setting."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
@@ -57,14 +57,14 @@ class WriteSettingRequest(smpmsg.WriteRequest):
     """Binary data to write."""
 
 
-class WriteSettingResponse(smpmsg.WriteResponse):
+class WriteSettingResponse(smpmsg.WriteResponse, frozen=True):
     """Write setting success response."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING
 
 
-class DeleteSettingRequest(smpmsg.WriteRequest):
+class DeleteSettingRequest(smpmsg.WriteRequest, frozen=True):
     """Delete setting."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
@@ -74,14 +74,14 @@ class DeleteSettingRequest(smpmsg.WriteRequest):
     """The name of the setting to delete."""
 
 
-class DeleteSettingResponse(smpmsg.WriteResponse):
+class DeleteSettingResponse(smpmsg.WriteResponse, frozen=True):
     """Delete setting success response."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.DELETE_SETTING
 
 
-class CommitSettingsRequest(smpmsg.WriteRequest):
+class CommitSettingsRequest(smpmsg.WriteRequest, frozen=True):
     """Commit pending settings.
 
     Commit settings command allows committing all settings that have been set
@@ -92,35 +92,35 @@ class CommitSettingsRequest(smpmsg.WriteRequest):
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS
 
 
-class CommitSettingsResponse(smpmsg.WriteResponse):
+class CommitSettingsResponse(smpmsg.WriteResponse, frozen=True):
     """Commit pending settings success response."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS
 
 
-class LoadSettingsRequest(smpmsg.ReadRequest):
+class LoadSettingsRequest(smpmsg.ReadRequest, frozen=True):
     """Load settings from persistent storage."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
 
 
-class LoadSettingsResponse(smpmsg.ReadResponse):
+class LoadSettingsResponse(smpmsg.ReadResponse, frozen=True):
     """Load settings from persistent storage success response."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
 
 
-class SaveSettingsRequest(smpmsg.WriteRequest):
+class SaveSettingsRequest(smpmsg.WriteRequest, frozen=True):
     """Save settings to persistent storage."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS
 
 
-class SaveSettingsResponse(smpmsg.WriteResponse):
+class SaveSettingsResponse(smpmsg.WriteResponse, frozen=True):
     """Save settings to persistent storage success response."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
@@ -156,13 +156,13 @@ class SETTINGS_MGMT_ERR(IntEnum):
     """The provided key name does not support being deleted."""
 
 
-class SettingsManagementErrorV1(smperr.ErrorV1):
+class SettingsManagementErrorV1(smperr.ErrorV1, frozen=True):
     """Error response to a settings management command."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT
 
 
-class SettingsManagementErrorV2(smperr.ErrorV2[SETTINGS_MGMT_ERR]):
+class SettingsManagementErrorV2(smperr.ErrorV2[SETTINGS_MGMT_ERR], frozen=True):
     """Error response to a settings management command."""
 
     _GROUP_ID = smphdr.GroupId.SETTINGS_MANAGEMENT

--- a/src/smp/shell_management.py
+++ b/src/smp/shell_management.py
@@ -5,25 +5,6 @@ from enum import IntEnum, unique
 from smp import error, header, message
 
 
-class ExecuteRequest(message.WriteRequest, frozen=True):
-    """Execute a shell command."""
-
-    _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ShellManagement.EXECUTE
-
-    argv: list[str]
-
-
-class ExecuteResponse(message.WriteResponse, frozen=True):
-    """Success response to a shell command execution."""
-
-    _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
-    _COMMAND_ID = header.CommandId.ShellManagement.EXECUTE
-
-    o: str
-    ret: int
-
-
 @unique
 class SHELL_MGMT_RET_RC(IntEnum):
     """Return codes for the shell management group."""
@@ -48,3 +29,28 @@ class ShellManagementErrorV2(error.ErrorV2[SHELL_MGMT_RET_RC], frozen=True):
     """Error response to a shell command execution."""
 
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
+
+
+class _ShellGroupBase:
+    _ErrorV1 = ShellManagementErrorV1
+    _ErrorV2 = ShellManagementErrorV2
+
+
+class ExecuteResponse(message.WriteResponse, frozen=True):
+    """Success response to a shell command execution."""
+
+    _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ShellManagement.EXECUTE
+
+    o: str
+    ret: int
+
+
+class ExecuteRequest(message.WriteRequest, _ShellGroupBase, frozen=True):
+    """Execute a shell command."""
+
+    _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
+    _COMMAND_ID = header.CommandId.ShellManagement.EXECUTE
+    _Response = ExecuteResponse
+
+    argv: list[str]

--- a/src/smp/shell_management.py
+++ b/src/smp/shell_management.py
@@ -5,7 +5,7 @@ from enum import IntEnum, unique
 from smp import error, header, message
 
 
-class ExecuteRequest(message.WriteRequest):
+class ExecuteRequest(message.WriteRequest, frozen=True):
     """Execute a shell command."""
 
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
@@ -14,7 +14,7 @@ class ExecuteRequest(message.WriteRequest):
     argv: list[str]
 
 
-class ExecuteResponse(message.WriteResponse):
+class ExecuteResponse(message.WriteResponse, frozen=True):
     """Success response to a shell command execution."""
 
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
@@ -38,13 +38,13 @@ class SHELL_MGMT_RET_RC(IntEnum):
     """The provided format value is not valid."""
 
 
-class ShellManagementErrorV1(error.ErrorV1):
+class ShellManagementErrorV1(error.ErrorV1, frozen=True):
     """Error response to a shell command execution."""
 
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT
 
 
-class ShellManagementErrorV2(error.ErrorV2[SHELL_MGMT_RET_RC]):
+class ShellManagementErrorV2(error.ErrorV2[SHELL_MGMT_RET_RC], frozen=True):
     """Error response to a shell command execution."""
 
     _GROUP_ID = header.GroupId.SHELL_MANAGEMENT

--- a/src/smp/statistics_management.py
+++ b/src/smp/statistics_management.py
@@ -7,7 +7,7 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class GroupDataRequest(smpmsg.ReadRequest):
+class GroupDataRequest(smpmsg.ReadRequest, frozen=True):
     """Read the statistics group data."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
@@ -16,7 +16,7 @@ class GroupDataRequest(smpmsg.ReadRequest):
     name: str
 
 
-class GroupDataResponse(smpmsg.ReadResponse):
+class GroupDataResponse(smpmsg.ReadResponse, frozen=True):
     """Statistics group data response."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
@@ -26,14 +26,14 @@ class GroupDataResponse(smpmsg.ReadResponse):
     fields: dict[str, int]
 
 
-class ListOfGroupsRequest(smpmsg.ReadRequest):
+class ListOfGroupsRequest(smpmsg.ReadRequest, frozen=True):
     """List the available statistics groups."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS
 
 
-class ListOfGroupsResponse(smpmsg.ReadResponse):
+class ListOfGroupsResponse(smpmsg.ReadResponse, frozen=True):
     """List of available statistics groups."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
@@ -65,13 +65,13 @@ class STAT_MGMT_ERR(IntEnum):
     """Walk through of statistics was aborted."""
 
 
-class StatisticsManagementErrorV1(smperr.ErrorV1):
+class StatisticsManagementErrorV1(smperr.ErrorV1, frozen=True):
     """Error response to a statistics management command."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
 
 
-class StatisticsManagementErrorV2(smperr.ErrorV2[STAT_MGMT_ERR]):
+class StatisticsManagementErrorV2(smperr.ErrorV2[STAT_MGMT_ERR], frozen=True):
     """Error response to a statistics management command."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT

--- a/src/smp/statistics_management.py
+++ b/src/smp/statistics_management.py
@@ -7,41 +7,6 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class GroupDataRequest(smpmsg.ReadRequest, frozen=True):
-    """Read the statistics group data."""
-
-    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.GROUP_DATA
-
-    name: str
-
-
-class GroupDataResponse(smpmsg.ReadResponse, frozen=True):
-    """Statistics group data response."""
-
-    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.GROUP_DATA
-
-    name: str
-    fields: dict[str, int]
-
-
-class ListOfGroupsRequest(smpmsg.ReadRequest, frozen=True):
-    """List the available statistics groups."""
-
-    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS
-
-
-class ListOfGroupsResponse(smpmsg.ReadResponse, frozen=True):
-    """List of available statistics groups."""
-
-    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS
-
-    stat_list: tuple[str, ...]
-
-
 @unique
 class STAT_MGMT_ERR(IntEnum):
     """Return codes for the statistics management group."""
@@ -75,3 +40,45 @@ class StatisticsManagementErrorV2(smperr.ErrorV2[STAT_MGMT_ERR], frozen=True):
     """Error response to a statistics management command."""
 
     _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
+
+
+class _StatisticsGroupBase:
+    _ErrorV1 = StatisticsManagementErrorV1
+    _ErrorV2 = StatisticsManagementErrorV2
+
+
+class GroupDataResponse(smpmsg.ReadResponse, frozen=True):
+    """Statistics group data response."""
+
+    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.GROUP_DATA
+
+    name: str
+    fields: dict[str, int]
+
+
+class GroupDataRequest(smpmsg.ReadRequest, _StatisticsGroupBase, frozen=True):
+    """Read the statistics group data."""
+
+    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.GROUP_DATA
+    _Response = GroupDataResponse
+
+    name: str
+
+
+class ListOfGroupsResponse(smpmsg.ReadResponse, frozen=True):
+    """List of available statistics groups."""
+
+    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS
+
+    stat_list: tuple[str, ...]
+
+
+class ListOfGroupsRequest(smpmsg.ReadRequest, _StatisticsGroupBase, frozen=True):
+    """List the available statistics groups."""
+
+    _GROUP_ID = smphdr.GroupId.STATISTICS_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS
+    _Response = ListOfGroupsResponse

--- a/src/smp/user/intercreate.py
+++ b/src/smp/user/intercreate.py
@@ -7,7 +7,7 @@ from enum import IntEnum, unique
 from smp import error, header, message
 
 
-class ImageUploadWriteRequest(message.WriteRequest):
+class ImageUploadWriteRequest(message.WriteRequest, frozen=True):
     """Upload an image to an application-defined location like a secondary MCU."""
 
     _GROUP_ID = header.UserGroupId.INTERCREATE
@@ -29,7 +29,7 @@ class ImageUploadWriteRequest(message.WriteRequest):
     """The SHA-256 hash of the image; optional when off == 0, else ignored."""
 
 
-class ImageUploadWriteResponse(message.WriteResponse):
+class ImageUploadWriteResponse(message.WriteResponse, frozen=True):
     """Success response to an image upload request."""
 
     _GROUP_ID = header.UserGroupId.INTERCREATE
@@ -50,13 +50,13 @@ class IC_MGMT_ERR(IntEnum):
     """No image matched the image provided."""
 
 
-class ErrorV1(error.ErrorV1):
+class ErrorV1(error.ErrorV1, frozen=True):
     """Intercreate Management error response."""
 
     _GROUP_ID = header.UserGroupId.INTERCREATE
 
 
-class ErrorV2(error.ErrorV2[IC_MGMT_ERR]):
+class ErrorV2(error.ErrorV2[IC_MGMT_ERR], frozen=True):
     """Intercreate Management error response."""
 
     _GROUP_ID = header.UserGroupId.INTERCREATE

--- a/src/smp/user/intercreate.py
+++ b/src/smp/user/intercreate.py
@@ -7,38 +7,6 @@ from enum import IntEnum, unique
 from smp import error, header, message
 
 
-class ImageUploadWriteRequest(message.WriteRequest, frozen=True):
-    """Upload an image to an application-defined location like a secondary MCU."""
-
-    _GROUP_ID = header.UserGroupId.INTERCREATE
-    _COMMAND_ID = header.CommandId.Intercreate.UPLOAD
-
-    off: int
-    """The offset in the image to write to."""
-
-    data: bytes
-    """The data to write to the image."""
-
-    image: int | None = None
-    """The image to write to; required when off == 0."""
-
-    len: int | None = None
-    """The length of the data to write; required when off == 0."""
-
-    sha: bytes | None = None
-    """The SHA-256 hash of the image; optional when off == 0, else ignored."""
-
-
-class ImageUploadWriteResponse(message.WriteResponse, frozen=True):
-    """Success response to an image upload request."""
-
-    _GROUP_ID = header.UserGroupId.INTERCREATE
-    _COMMAND_ID = header.CommandId.Intercreate.UPLOAD
-
-    off: int
-    """The offset in the image after the request was written."""
-
-
 @unique
 class IC_MGMT_ERR(IntEnum):
     """Intercreate Management error codes."""
@@ -60,3 +28,41 @@ class ErrorV2(error.ErrorV2[IC_MGMT_ERR], frozen=True):
     """Intercreate Management error response."""
 
     _GROUP_ID = header.UserGroupId.INTERCREATE
+
+
+class _IntercreateGroupBase:
+    _ErrorV1 = ErrorV1
+    _ErrorV2 = ErrorV2
+
+
+class ImageUploadWriteResponse(message.WriteResponse, frozen=True):
+    """Success response to an image upload request."""
+
+    _GROUP_ID = header.UserGroupId.INTERCREATE
+    _COMMAND_ID = header.CommandId.Intercreate.UPLOAD
+
+    off: int
+    """The offset in the image after the request was written."""
+
+
+class ImageUploadWriteRequest(message.WriteRequest, _IntercreateGroupBase, frozen=True):
+    """Upload an image to an application-defined location like a secondary MCU."""
+
+    _GROUP_ID = header.UserGroupId.INTERCREATE
+    _COMMAND_ID = header.CommandId.Intercreate.UPLOAD
+    _Response = ImageUploadWriteResponse
+
+    off: int
+    """The offset in the image to write to."""
+
+    data: bytes
+    """The data to write to the image."""
+
+    image: int | None = None
+    """The image to write to; required when off == 0."""
+
+    len: int | None = None
+    """The length of the data to write; required when off == 0."""
+
+    sha: bytes | None = None
+    """The SHA-256 hash of the image; optional when off == 0, else ignored."""

--- a/src/smp/zephyr_management.py
+++ b/src/smp/zephyr_management.py
@@ -7,20 +7,6 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class EraseStorageRequest(smpmsg.WriteRequest, frozen=True):
-    """Erase the storage area."""
-
-    _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.ZephyrManagement.ERASE_STORAGE
-
-
-class EraseStorageResponse(smpmsg.WriteResponse, frozen=True):
-    """Success response to a storage area erase."""
-
-    _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
-    _COMMAND_ID = smphdr.CommandId.ZephyrManagement.ERASE_STORAGE
-
-
 @unique
 class ZEPHYRBASIC_MGMT_ERR(IntEnum):
     """Return codes for the Zephyr Management group."""
@@ -51,3 +37,23 @@ class ZephyrManagementErrorV2(smperr.ErrorV2[ZEPHYRBASIC_MGMT_ERR], frozen=True)
     """Error response to a Zephyr Management command."""
 
     _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
+
+
+class _ZephyrGroupBase:
+    _ErrorV1 = ZephyrManagementErrorV1
+    _ErrorV2 = ZephyrManagementErrorV2
+
+
+class EraseStorageResponse(smpmsg.WriteResponse, frozen=True):
+    """Success response to a storage area erase."""
+
+    _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.ZephyrManagement.ERASE_STORAGE
+
+
+class EraseStorageRequest(smpmsg.WriteRequest, _ZephyrGroupBase, frozen=True):
+    """Erase the storage area."""
+
+    _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
+    _COMMAND_ID = smphdr.CommandId.ZephyrManagement.ERASE_STORAGE
+    _Response = EraseStorageResponse

--- a/src/smp/zephyr_management.py
+++ b/src/smp/zephyr_management.py
@@ -7,14 +7,14 @@ import smp.header as smphdr
 import smp.message as smpmsg
 
 
-class EraseStorageRequest(smpmsg.WriteRequest):
+class EraseStorageRequest(smpmsg.WriteRequest, frozen=True):
     """Erase the storage area."""
 
     _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
     _COMMAND_ID = smphdr.CommandId.ZephyrManagement.ERASE_STORAGE
 
 
-class EraseStorageResponse(smpmsg.WriteResponse):
+class EraseStorageResponse(smpmsg.WriteResponse, frozen=True):
     """Success response to a storage area erase."""
 
     _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
@@ -41,13 +41,13 @@ class ZEPHYRBASIC_MGMT_ERR(IntEnum):
     """Erasing the flash area has failed."""
 
 
-class ZephyrManagementErrorV1(smperr.ErrorV1):
+class ZephyrManagementErrorV1(smperr.ErrorV1, frozen=True):
     """Error response to a Zephyr Management command."""
 
     _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT
 
 
-class ZephyrManagementErrorV2(smperr.ErrorV2[ZEPHYRBASIC_MGMT_ERR]):
+class ZephyrManagementErrorV2(smperr.ErrorV2[ZEPHYRBASIC_MGMT_ERR], frozen=True):
     """Error response to a Zephyr Management command."""
 
     _GROUP_ID = smphdr.GroupId.ZEPHYR_MANAGEMENT

--- a/tests/binary_regressions/test_binary_lock.py
+++ b/tests/binary_regressions/test_binary_lock.py
@@ -1,14 +1,18 @@
 """This tests locked de/serializations."""
 
+from __future__ import annotations
+
 import importlib
 import json
 from pathlib import Path
-from typing import Any, Final, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 import pytest
 
-import smp.message as smpmsg
-from smp.file_management import FileHashChecksumResponse
+from smp import header
+
+if TYPE_CHECKING:
+    from smp.message import Data
 
 pytestmark = pytest.mark.slow
 
@@ -17,69 +21,41 @@ class Record(NamedTuple):
     message: str
     version: int
     sequence: int
-    kwargs: dict
+    kwargs: dict[str, Any]
     bytes: str
 
 
-records: Final[list[Record]] = []
-for file in list(Path("tests", "binary_regressions", "records").rglob("*.json")):
-    with open(file) as f:
-        records.extend(Record(**json.loads(x)) for x in f.readlines())
+records: Final[list[Record]] = [
+    Record(**json.loads(line))
+    for file in Path("tests", "binary_regressions", "records").rglob("*.json")
+    for line in file.read_text().splitlines()
+]
 
 
-def import_class(full_class_path: str) -> smpmsg._MessageBase:
-    module_path, class_name = full_class_path.rsplit('.', 1)
+def import_class(full_class_path: str) -> type[Data]:
+    module_path, class_name = full_class_path.rsplit(".", 1)
     return getattr(importlib.import_module(module_path), class_name)
 
 
-def compare_values(expected: Any, actual: Any) -> None:
-    """Recursively compare expected and actual values."""
-    if isinstance(expected, dict):
-        if not isinstance(actual, dict):
-            actual = actual.model_dump()
-        for k, v in expected.items():
-            assert k in actual, f"Key {k} not found in actual"
-            compare_values(v, actual[k])
-    elif isinstance(expected, (list, tuple)):
-        assert len(expected) == len(actual), (
-            f"Expected list of length {len(expected)}, got {len(actual)}"
-        )
-        for e, a in zip(expected, actual, strict=True):
-            compare_values(e, a)
-    else:
-        assert expected == actual, f"Expected {expected}, got {actual}"
+def fixup(kwargs: dict[str, Any], message: str) -> dict[str, Any]:
+    out = dict(kwargs)
+    for key in ("data", "sha", "val"):
+        if isinstance(out.get(key), str):
+            out[key] = bytes.fromhex(out[key])
+    if message.endswith("FileHashChecksumResponse") and isinstance(out.get("output"), str):
+        out["output"] = bytes.fromhex(out["output"])
+    if "images" in out:
+        out["images"] = [
+            {**image, **({"hash": b"A"} if "hash" in image else {})} for image in out["images"]
+        ]
+    return out
 
 
 @pytest.mark.parametrize("record", records)
 def test_binary_lock(record: Record) -> None:
-    cls: Final = import_class(record.message)
-
-    if "data" in record.kwargs:
-        record.kwargs["data"] = bytes.fromhex(record.kwargs["data"])
-    if "images" in record.kwargs:
-        for image in record.kwargs["images"]:
-            if "hash" in image:
-                image["hash"] = b"A"
-    if "sha" in record.kwargs:
-        record.kwargs["sha"] = bytes.fromhex(record.kwargs["sha"])
-    if "val" in record.kwargs:
-        record.kwargs["val"] = bytes.fromhex(record.kwargs["val"])
-    if (
-        cls is FileHashChecksumResponse
-        and "output" in record.kwargs
-        and isinstance(record.kwargs["output"], str)
-    ):
-        record.kwargs["output"] = bytes.fromhex(record.kwargs["output"])
-
-    # Test serialization match
-    serialized_message = cls(version=record.version, sequence=record.sequence, **record.kwargs)  # type: ignore
-    assert bytes(serialized_message) == bytes.fromhex(record.bytes)
-
-    # Test deserialization match
-    deserialized_message = cls.loads(bytes.fromhex(record.bytes))
-
-    assert serialized_message == deserialized_message
-
-    for k, v in record.kwargs.items():
-        actual_value: Any = getattr(deserialized_message, k)
-        compare_values(v, actual_value)
+    cls = import_class(record.message)
+    frame = cls._convert_mapping(fixup(record.kwargs, record.message)).to_frame(
+        version=header.Version(record.version), sequence=record.sequence
+    )
+    assert bytes(frame) == bytes.fromhex(record.bytes)
+    assert cls.loads(bytes.fromhex(record.bytes)) == frame

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,38 +1,40 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TypeVar
 
 from smp import header as smpheader
+from smp import message as smpmessage
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from smp.message import _MessageBase
+T = TypeVar("T", bound=smpmessage.Data)
 
 
-def make_assert_header(
-    group_id: smpheader.GroupId | smpheader.UserGroupId,
+def assert_frame(
+    data: T,
+    *,
     op: smpheader.OP,
+    group_id: smpheader.GroupIdField,
     command_id: smpheader.AnyCommandId,
-    length: int | None,
-) -> Callable[[_MessageBase], None]:
-    """Return an `assert_header` function."""
+    length: int | None = None,
+    version: smpheader.Version = smpheader.Version.V2,
+    flags: smpheader.Flag = smpheader.Flag.UNUSED,
+    sequence: int = 0,
+) -> smpmessage.Frame[T]:
+    """Assert `data`'s header and a byte-exact round-trip; returns the decoded Frame."""
+    frame = data.to_frame(version=version, flags=flags, sequence=sequence)
+    header = frame.header
+    assert header.op == op
+    assert header.version == version
+    assert header.flags == flags
+    assert header.group_id == group_id
+    assert header.command_id == command_id
+    assert 0 <= header.sequence <= 0xFF
+    assert 0 <= header.length <= 0xFFFF
+    if length is not None:
+        assert header.length == length
 
-    def f(
-        r: _MessageBase,
-    ) -> None:
-        h = r.header
-        assert op == h.op
-        assert h.version == smpheader.Version.V2
-        assert h.flags == 0
-        if length is not None:
-            assert length == h.length
-        else:
-            assert 0 <= h.length <= 0xFFFF
-        assert group_id == h.group_id
-        assert 0 <= h.sequence <= 0xFF
-        assert command_id == h.command_id
+    wire = bytes(frame)
+    assert wire[: smpheader.Header.SIZE] == bytes(header)
 
-        assert bytes(r) == r.BYTES
-
-    return f
+    decoded = type(data).loads(wire)
+    assert decoded == frame
+    return decoded

--- a/tests/test_enumeration_management.py
+++ b/tests/test_enumeration_management.py
@@ -2,160 +2,165 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from functools import partial
 
-import cbor2
+import msgspec
 import pytest
 
 from smp import enumeration_management as smpenum
 from smp import header as smphdr
-from smp import message as smpmsg
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
 
-if TYPE_CHECKING:
-    from pydantic import BaseModel
+enumcmd = smphdr.CommandId.EnumManagement
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.EnumManagement,
-    data: dict[str, Any],
-    nested_model: type[BaseModel] | None = None,
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.ENUM_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            if type(v) is tuple and nested_model is not None:
-                for v2 in v:
-                    assert v2 == nested_model(**v2).model_dump()
-            else:
-                assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+make_header = partial(
+    smphdr.Header,
+    op=smphdr.OP.READ_RSP,
+    version=smphdr.Version.V2,
+    flags=smphdr.Flag(0),
+    length=0,
+    group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+    sequence=0,
+    command_id=enumcmd.LIST_OF_GROUPS,
+)
 
 
 def test_GroupCountRequest() -> None:
-    _do_test(
-        smpenum.GroupCountRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.EnumManagement.GROUP_COUNT,
-        {},
+    assert_frame(
+        smpenum.GroupCountRequest(),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_COUNT,
+        length=1,
     )
 
 
 def test_GroupCountResponse() -> None:
-    r = _do_test(
-        smpenum.GroupCountResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.EnumManagement.GROUP_COUNT,
-        {"count": 2},
+    frame = assert_frame(
+        smpenum.GroupCountResponse(count=2),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_COUNT,
     )
-    assert r.count == 2
+    assert frame.data.count == 2
 
 
 def test_ListOfGroupsRequest() -> None:
-    _do_test(
-        smpenum.ListOfGroupsRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.EnumManagement.LIST_OF_GROUPS,
-        {},
+    assert_frame(
+        smpenum.ListOfGroupsRequest(),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.LIST_OF_GROUPS,
+        length=1,
     )
 
 
 def test_ListOfGroupsResponse() -> None:
-    r = _do_test(
-        smpenum.ListOfGroupsResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.EnumManagement.LIST_OF_GROUPS,
-        {"groups": (2, smphdr.GroupId.RUNTIME_TESTS, 15, 64)},
+    frame = assert_frame(
+        smpenum.ListOfGroupsResponse(groups=(2, smphdr.GroupId.RUNTIME_TESTS, 15, 64)),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.LIST_OF_GROUPS,
     )
-    assert r.groups == (2, 5, 15, 64)
+    groups = frame.data.groups
+    assert groups == (2, 5, 15, 64)
 
-    assert type(r.groups[0]) is smphdr.GroupId
-    assert r.groups[0] == smphdr.GroupId.STATISTICS_MANAGEMENT
-
-    assert type(r.groups[1]) is smphdr.GroupId
-    assert r.groups[1] == smphdr.GroupId.RUNTIME_TESTS
-
-    assert type(r.groups[2]) is int
-    assert r.groups[2] == 15
-
-    assert type(r.groups[3]) is smphdr.UserGroupId
-    assert r.groups[3] == smphdr.UserGroupId.INTERCREATE
+    assert type(groups[0]) is smphdr.GroupId
+    assert groups[0] == smphdr.GroupId.STATISTICS_MANAGEMENT
+    assert type(groups[1]) is smphdr.GroupId
+    assert groups[1] == smphdr.GroupId.RUNTIME_TESTS
+    assert type(groups[2]) is int
+    assert groups[2] == 15
+    assert type(groups[3]) is smphdr.UserGroupId
+    assert groups[3] == smphdr.UserGroupId.INTERCREATE
 
 
 @pytest.mark.parametrize("index", [0, 1, None])
 def test_GroupIdRequest(index: int | None) -> None:
-    _do_test(
-        smpenum.GroupIdRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.EnumManagement.GROUP_ID,
-        {"index": index} if index is not None else {},
+    assert_frame(
+        smpenum.GroupIdRequest(index=index),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_ID,
     )
 
 
 def test_GroupIdResponse() -> None:
-    r = _do_test(
-        smpenum.GroupIdResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.EnumManagement.GROUP_ID,
-        {"group": 2},
+    frame = assert_frame(
+        smpenum.GroupIdResponse(group=2),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_ID,
     )
-    assert r.group == smphdr.GroupId.STATISTICS_MANAGEMENT
-    assert type(r.group) is smphdr.GroupId
-    assert not r.end
+    assert frame.data.group == smphdr.GroupId.STATISTICS_MANAGEMENT
+    assert type(frame.data.group) is smphdr.GroupId
+    assert not frame.data.end
 
 
 def test_GroupDetailsRequest() -> None:
-    _do_test(
-        smpenum.GroupDetailsRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.EnumManagement.GROUP_DETAILS,
-        {"groups": (smphdr.GroupId.STATISTICS_MANAGEMENT, smphdr.GroupId.RUNTIME_TESTS, 15)},
+    assert_frame(
+        smpenum.GroupDetailsRequest(
+            groups=(smphdr.GroupId.STATISTICS_MANAGEMENT, smphdr.GroupId.RUNTIME_TESTS, 15)
+        ),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_DETAILS,
     )
-
-    _do_test(
-        smpenum.GroupDetailsRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.EnumManagement.GROUP_DETAILS,
-        {},
+    assert_frame(
+        smpenum.GroupDetailsRequest(),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_DETAILS,
+        length=1,
     )
 
 
 def test_GroupDetailsResponse() -> None:
-    r = _do_test(
-        smpenum.GroupDetailsResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.EnumManagement.GROUP_DETAILS,
-        {
-            "groups": (
-                {"group": 2, "name": "group2", "handlers": 2},
-                {"group": 5, "name": "group5", "handlers": 5},
-                {"group": 15, "name": "group15", "handlers": 15},
-                {"group": 64, "name": "group64", "handlers": 64},
+    frame = assert_frame(
+        smpenum.GroupDetailsResponse(
+            groups=(
+                smpenum.GroupDetails(group=2, name="group2", handlers=2),
+                smpenum.GroupDetails(group=5, name="group5", handlers=5),
+                smpenum.GroupDetails(group=15, name="group15", handlers=15),
+                smpenum.GroupDetails(group=64, name="group64", handlers=64),
             )
-        },
-        nested_model=smpenum.GroupDetails,
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.ENUM_MANAGEMENT,
+        command_id=enumcmd.GROUP_DETAILS,
     )
-    assert r.groups == (
+    groups = frame.data.groups
+    assert groups == (
         smpenum.GroupDetails(group=2, name="group2", handlers=2),
         smpenum.GroupDetails(group=5, name="group5", handlers=5),
         smpenum.GroupDetails(group=15, name="group15", handlers=15),
         smpenum.GroupDetails(group=64, name="group64", handlers=64),
     )
-    assert type(r.groups[0].group) is smphdr.GroupId
-    assert type(r.groups[1].group) is smphdr.GroupId
-    assert type(r.groups[2].group) is int
-    assert type(r.groups[3].group) is smphdr.UserGroupId
+    assert type(groups[0].group) is smphdr.GroupId
+    assert type(groups[1].group) is smphdr.GroupId
+    assert type(groups[2].group) is int
+    assert type(groups[3].group) is smphdr.UserGroupId
+
+
+def test_ListOfGroupsResponse_rejects_missing_groups() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpenum.ListOfGroupsResponse.load(make_header(command_id=enumcmd.LIST_OF_GROUPS), {})
+
+
+def test_GroupIdResponse_rejects_missing_group() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpenum.GroupIdResponse.load(make_header(command_id=enumcmd.GROUP_ID), {"end": True})
+
+
+def test_GroupIdResponse_rejects_unknown_field() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpenum.GroupIdResponse.load(
+            make_header(command_id=enumcmd.GROUP_ID), {"group": 2, "bogus": 1}
+        )
+
+
+def test_GroupDetailsResponse_rejects_missing_group_in_element() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpenum.GroupDetailsResponse.load(
+            make_header(command_id=enumcmd.GROUP_DETAILS), {"groups": [{"name": "x"}]}
+        )

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -6,8 +6,8 @@ from enum import IntEnum
 from functools import partial
 
 import cbor2
+import msgspec
 import pytest
-from pydantic import ValidationError
 
 from smp import header as smpheader
 from smp.error import MGMT_ERR, ErrorV1, ErrorV2
@@ -18,11 +18,11 @@ class FAKE_ERR(IntEnum):
     ERR = 1
 
 
-class FakeErrorV1(ErrorV1):
+class FakeErrorV1(ErrorV1, frozen=True):
     _GROUP_ID = smpheader.GroupId.IMAGE_MANAGEMENT
 
 
-class FakeErrorV2(ErrorV2[FAKE_ERR]):
+class FakeErrorV2(ErrorV2[FAKE_ERR], frozen=True):
     _GROUP_ID = smpheader.GroupId.IMAGE_MANAGEMENT
 
 
@@ -39,44 +39,58 @@ make_header = partial(
 
 @pytest.mark.parametrize("rc", [e.value for e in MGMT_ERR])
 @pytest.mark.parametrize("rsn", ["something", None])
-def test_ErrorV1(rc: MGMT_ERR, rsn: str | None) -> None:
-    d = cbor2.dumps({"rc": rc} if rsn is None else {"rc": rc, "rsn": rsn})  # type: ignore
+def test_ErrorV1(rc: int, rsn: str | None) -> None:
+    d = cbor2.dumps({"rc": rc} if rsn is None else {"rc": rc, "rsn": rsn})
     h = make_header(length=len(d))
 
-    if rc > max(MGMT_ERR):
-        with pytest.raises(ValidationError):
-            FakeErrorV1.loads(h.BYTES + d)
-        return
-
-    e = FakeErrorV1.loads(h.BYTES + d)
-    assert MGMT_ERR is type(e.rc)
-    assert rc == e.rc
+    frame = FakeErrorV1.loads(bytes(h) + d)
+    assert MGMT_ERR is type(frame.data.rc)
+    assert rc == frame.data.rc
     if rsn is not None:
-        assert rsn == e.rsn
+        assert rsn == frame.data.rsn
     else:
-        assert None is e.rsn
+        assert frame.data.rsn is None
 
-    with pytest.raises(ValidationError):
-        FakeErrorV2.loads(h.BYTES + d)
+    with pytest.raises(msgspec.ValidationError):
+        FakeErrorV2.loads(bytes(h) + d)
 
 
 @pytest.mark.parametrize("rc", [FAKE_ERR.OK, FAKE_ERR.ERR, 2])
 @pytest.mark.parametrize(
     "group", [smpheader.GroupId.OS_MANAGEMENT, smpheader.GroupId.IMAGE_MANAGEMENT]
 )
-def test_ErrorV2(rc: FAKE_ERR, group: smpheader.GroupId) -> None:
+def test_ErrorV2(rc: int, group: smpheader.GroupId) -> None:
     d = cbor2.dumps({"err": {"rc": rc, "group": group}})
     h = make_header(length=len(d))
 
     if rc > max(FAKE_ERR):
-        with pytest.raises(ValidationError):
-            FakeErrorV2.loads(h.BYTES + d)
+        with pytest.raises(msgspec.ValidationError):
+            FakeErrorV2.loads(bytes(h) + d)
         return
 
-    e = FakeErrorV2.loads(h.BYTES + d)
-    assert FAKE_ERR is type(e.err.rc)
-    assert rc == e.err.rc
-    assert group == e.err.group
+    frame = FakeErrorV2.loads(bytes(h) + d)
+    assert FAKE_ERR is type(frame.data.err.rc)
+    assert rc == frame.data.err.rc
+    assert group == frame.data.err.group
 
-    with pytest.raises(ValidationError):
-        FakeErrorV1.loads(h.BYTES + d)
+    with pytest.raises(msgspec.ValidationError):
+        FakeErrorV1.loads(bytes(h) + d)
+
+
+def test_ErrorV2_rejects_missing_err() -> None:
+    d = cbor2.dumps({})
+    h = make_header(length=len(d))
+    with pytest.raises(msgspec.ValidationError):
+        FakeErrorV2.loads(bytes(h) + d)
+
+
+def test_ErrorV2_rejects_unknown_err_field() -> None:
+    d = cbor2.dumps({"err": {"group": 0, "rc": 0, "bogus": 1}})
+    h = make_header(length=len(d))
+    with pytest.raises(msgspec.ValidationError):
+        FakeErrorV2.loads(bytes(h) + d)
+
+
+def test_ErrorV2_rc_type_requires_parametrization() -> None:
+    with pytest.raises(TypeError):
+        ErrorV2._rc_type()

--- a/tests/test_file_management.py
+++ b/tests/test_file_management.py
@@ -2,194 +2,163 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
-
-import cbor2
-
 from smp import file_management as smpfs
 from smp import header as smphdr
-from smp import message as smpmsg
-from tests.helpers import make_assert_header
-
-if TYPE_CHECKING:
-    from pydantic import BaseModel
-
-T = TypeVar("T", bound=smpmsg._MessageBase)
+from tests.helpers import assert_frame
 
 fscmd = smphdr.CommandId.FileManagement
 
 
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.FileManagement,
-    data: dict[str, Any],
-    nested_model: type[BaseModel] | None = None,
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.FILE_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            if type(v) is dict and nested_model is not None:
-                for k2, v2 in v.items():
-                    one_deep = getattr(r, k)
-                    assert isinstance(one_deep[k2], nested_model)
-                    assert v2 == one_deep[k2].model_dump()
-            else:
-                assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
-
-
 def test_FileDownloadRequest() -> None:
-    r = _do_test(
-        smpfs.FileDownloadRequest,
-        smphdr.OP.READ,
-        fscmd.FILE_DOWNLOAD_UPLOAD,
-        {"off": 0, "name": "test_file.txt"},
+    frame = assert_frame(
+        smpfs.FileDownloadRequest(off=0, name="test_file.txt"),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_DOWNLOAD_UPLOAD,
     )
-    assert r.off == 0
-    assert r.name == "test_file.txt"
+    assert frame.data.off == 0
+    assert frame.data.name == "test_file.txt"
 
 
 def test_FileDownloadResponse() -> None:
-    r = _do_test(
-        smpfs.FileDownloadResponse,
-        smphdr.OP.READ_RSP,
-        fscmd.FILE_DOWNLOAD_UPLOAD,
-        {"off": 0, "data": b"test", "len": 100},
+    frame = assert_frame(
+        smpfs.FileDownloadResponse(off=0, data=b"test", len=100),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_DOWNLOAD_UPLOAD,
     )
-    assert r.off == 0
-    assert r.data == b"test"
-    assert r.len == 100
+    assert frame.data.off == 0
+    assert frame.data.data == b"test"
+    assert frame.data.len == 100
 
 
 def test_FileUploadRequest() -> None:
-    r = _do_test(
-        smpfs.FileUploadRequest,
-        smphdr.OP.WRITE,
-        fscmd.FILE_DOWNLOAD_UPLOAD,
-        {"off": 0, "data": b"test", "name": "test.txt", "len": 1000},
+    frame = assert_frame(
+        smpfs.FileUploadRequest(off=0, data=b"test", name="test.txt", len=1000),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_DOWNLOAD_UPLOAD,
     )
-    assert r.off == 0
-    assert r.data == b"test"
-    assert r.name == "test.txt"
-    assert r.len == 1000
+    assert frame.data.off == 0
+    assert frame.data.data == b"test"
+    assert frame.data.name == "test.txt"
+    assert frame.data.len == 1000
 
 
 def test_FileUploadResponse() -> None:
-    r = _do_test(
-        smpfs.FileUploadResponse,
-        smphdr.OP.WRITE_RSP,
-        fscmd.FILE_DOWNLOAD_UPLOAD,
-        {"off": 0},
+    frame = assert_frame(
+        smpfs.FileUploadResponse(off=0),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_DOWNLOAD_UPLOAD,
     )
-    assert r.off == 0
+    assert frame.data.off == 0
 
 
 def test_FileStatusRequest() -> None:
-    r = _do_test(
-        smpfs.FileStatusRequest,
-        smphdr.OP.READ,
-        fscmd.FILE_STATUS,
-        {"name": "test.txt"},
+    frame = assert_frame(
+        smpfs.FileStatusRequest(name="test.txt"),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_STATUS,
     )
-    assert r.name == "test.txt"
+    assert frame.data.name == "test.txt"
 
 
 def test_FileStatusResponse() -> None:
-    r = _do_test(
-        smpfs.FileStatusResponse,
-        smphdr.OP.READ_RSP,
-        fscmd.FILE_STATUS,
-        {"len": 100},
+    frame = assert_frame(
+        smpfs.FileStatusResponse(len=100),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_STATUS,
     )
-    assert r.len == 100
+    assert frame.data.len == 100
 
 
 def test_FileHashChecksumRequest() -> None:
-    r = _do_test(
-        smpfs.FileHashChecksumRequest,
-        smphdr.OP.READ,
-        fscmd.FILE_HASH_CHECKSUM,
-        {"name": "test.txt", "type": "crc32", "off": 0, "len": 100},
+    frame = assert_frame(
+        smpfs.FileHashChecksumRequest(name="test.txt", type="crc32", off=0, len=100),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_HASH_CHECKSUM,
     )
-    assert r.name == "test.txt"
-    assert r.type == "crc32"
-    assert r.off == 0
-    assert r.len == 100
+    assert frame.data.name == "test.txt"
+    assert frame.data.type == "crc32"
+    assert frame.data.off == 0
+    assert frame.data.len == 100
 
 
 def test_FileHashChecksumResponse_bytes() -> None:
-    r = _do_test(
-        smpfs.FileHashChecksumResponse,
-        smphdr.OP.READ_RSP,
-        fscmd.FILE_HASH_CHECKSUM,
-        {"type": "crc32", "off": 0, "len": 100, "output": b"test"},
+    frame = assert_frame(
+        smpfs.FileHashChecksumResponse(type="crc32", off=0, len=100, output=b"test"),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_HASH_CHECKSUM,
     )
-    assert r.type == "crc32"
-    assert r.off == 0
-    assert r.len == 100
-    assert r.output == b"test"
+    assert frame.data.type == "crc32"
+    assert frame.data.off == 0
+    assert frame.data.len == 100
+    assert frame.data.output == b"test"
 
 
 def test_FileHashChecksumResponse_int() -> None:
-    r = _do_test(
-        smpfs.FileHashChecksumResponse,
-        smphdr.OP.READ_RSP,
-        fscmd.FILE_HASH_CHECKSUM,
-        {"type": "crc32", "off": 0, "len": 100, "output": 1000000},
+    frame = assert_frame(
+        smpfs.FileHashChecksumResponse(type="crc32", off=0, len=100, output=1000000),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_HASH_CHECKSUM,
     )
-    assert r.type == "crc32"
-    assert r.off == 0
-    assert r.len == 100
-    assert r.output == 1000000
+    assert frame.data.type == "crc32"
+    assert frame.data.off == 0
+    assert frame.data.len == 100
+    assert frame.data.output == 1000000
 
 
 def test_SupportedFileHashChecksumTypesRequest() -> None:
-    _do_test(
-        smpfs.SupportedFileHashChecksumTypesRequest,
-        smphdr.OP.READ,
-        fscmd.SUPPORTED_FILE_HASH_CHECKSUM_TYPES,
-        {},
+    assert_frame(
+        smpfs.SupportedFileHashChecksumTypesRequest(),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.SUPPORTED_FILE_HASH_CHECKSUM_TYPES,
+        length=1,
     )
 
 
 def test_SupportedFileHashChecksumTypesResponse() -> None:
-    r = _do_test(
-        smpfs.SupportedFileHashChecksumTypesResponse,
-        smphdr.OP.READ_RSP,
-        fscmd.SUPPORTED_FILE_HASH_CHECKSUM_TYPES,
-        {"types": {"crc32": {"format": 1, "size": 4}, "sha256": {"format": 0, "size": 32}}},
-        nested_model=smpfs.HashChecksumType,
+    frame = assert_frame(
+        smpfs.SupportedFileHashChecksumTypesResponse(
+            types={
+                "crc32": smpfs.HashChecksumType(format=smpfs.HashChecksumFormat.BYTE_ARRAY, size=4),
+                "sha256": smpfs.HashChecksumType(
+                    format=smpfs.HashChecksumFormat.NUMERICAL, size=32
+                ),
+            }
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.SUPPORTED_FILE_HASH_CHECKSUM_TYPES,
     )
-    assert r.types["crc32"].format == 1
-    assert r.types["crc32"].size == 4
-    assert r.types["sha256"].format == 0
-    assert r.types["sha256"].size == 32
+    assert frame.data.types["crc32"].format == smpfs.HashChecksumFormat.BYTE_ARRAY
+    assert frame.data.types["crc32"].size == 4
+    assert frame.data.types["sha256"].format == smpfs.HashChecksumFormat.NUMERICAL
+    assert frame.data.types["sha256"].size == 32
 
 
 def test_FileCloseRequest() -> None:
-    _do_test(
-        smpfs.FileCloseRequest,
-        smphdr.OP.WRITE,
-        fscmd.FILE_CLOSE,
-        {},
+    assert_frame(
+        smpfs.FileCloseRequest(),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_CLOSE,
+        length=1,
     )
 
 
 def test_FileCloseResponse() -> None:
-    _do_test(
-        smpfs.FileCloseResponse,
-        smphdr.OP.WRITE_RSP,
-        fscmd.FILE_CLOSE,
-        {},
+    assert_frame(
+        smpfs.FileCloseResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.FILE_MANAGEMENT,
+        command_id=fscmd.FILE_CLOSE,
+        length=1,
     )

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,38 @@
+"""Runtime behavior of the request/response type-narrowing helpers."""
+
+from __future__ import annotations
+
+from smp import error, header
+from smp import image_management as img
+from tests.test_generics_typing import error as is_error
+from tests.test_generics_typing import error_v1, error_v2, success
+
+_SUCCESS = img.ImageStatesReadResponse(images=[])
+_ERR_V1 = img.ImageManagementErrorV1(rc=error.MGMT_ERR.EUNKNOWN)
+_ERR_V2 = img.ImageManagementErrorV2(
+    err=error.Err(group=header.GroupId.IMAGE_MANAGEMENT, rc=img.IMG_MGMT_ERR.UNKNOWN)
+)
+
+
+def test_success() -> None:
+    assert success(_SUCCESS) is True
+    assert success(_ERR_V1) is False
+    assert success(_ERR_V2) is False
+
+
+def test_error_v1() -> None:
+    assert error_v1(_ERR_V1) is True
+    assert error_v1(_SUCCESS) is False
+    assert error_v1(_ERR_V2) is False
+
+
+def test_error_v2() -> None:
+    assert error_v2(_ERR_V2) is True
+    assert error_v2(_SUCCESS) is False
+    assert error_v2(_ERR_V1) is False
+
+
+def test_error() -> None:
+    assert is_error(_ERR_V1) is True
+    assert is_error(_ERR_V2) is True
+    assert is_error(_SUCCESS) is False

--- a/tests/test_generics_typing.py
+++ b/tests/test_generics_typing.py
@@ -1,0 +1,159 @@
+"""Static request/response narrowing assertions for `smp.SMPRequest`.
+
+These functions are verified by mypy and pyright (the `typecheck` task); they
+encode the exhaustiveness contract binding each `Request` to its `Response`,
+`ErrorV1`, and `ErrorV2`. They are not executed as runtime tests.
+
+The `TypeIs` narrowing helpers and the `_request` stub below stand in for an SMP
+client: they demonstrate that `SMPRequest` and all of its implementations
+support exhaustive narrowing, without the `smp` library having to ship them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from typing_extensions import assert_never, assert_type
+
+from smp import SMPRequest
+from smp import enumeration_management as enum
+from smp import file_management as fs
+from smp import image_management as img
+from smp import message as smpmessage
+from smp import os_management as os
+from smp import settings_management as settings
+from smp import shell_management as shell
+from smp import statistics_management as stat
+from smp import zephyr_management as zephyr
+from smp.user import intercreate as ic
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeIs
+
+    from smp import error as smperror
+
+TRep = TypeVar("TRep", bound="smpmessage.ReadResponse | smpmessage.WriteResponse")
+TEr1 = TypeVar("TEr1", bound="smperror.ErrorV1")
+TEr2 = TypeVar("TEr2", bound="smperror.ErrorV2")
+
+
+def success(
+    response: smpmessage.Response,
+) -> TypeIs[smpmessage.ReadResponse | smpmessage.WriteResponse]:
+    return response.RESPONSE_TYPE == smpmessage.ResponseType.SUCCESS
+
+
+def error_v1(response: smpmessage.Response) -> TypeIs[smperror.ErrorV1]:
+    return response.RESPONSE_TYPE == smpmessage.ResponseType.ERROR_V1
+
+
+def error_v2(response: smpmessage.Response) -> TypeIs[smperror.ErrorV2[Any]]:
+    return response.RESPONSE_TYPE == smpmessage.ResponseType.ERROR_V2
+
+
+def error(response: smpmessage.Response) -> TypeIs[smperror.ErrorV1 | smperror.ErrorV2[Any]]:
+    return error_v1(response) or error_v2(response)
+
+
+def _request(request: SMPRequest[TRep, TEr1, TEr2]) -> TRep | TEr1 | TEr2:
+    """Stand-in for `smpclient.SMPClient.request` that drives the static checks."""
+    raise NotImplementedError
+
+
+def _check_read_narrowing() -> None:
+    response = _request(img.ImageStatesReadRequest())
+    assert_type(
+        response,
+        img.ImageStatesReadResponse | img.ImageManagementErrorV1 | img.ImageManagementErrorV2,
+    )
+    if success(response):
+        assert_type(response, img.ImageStatesReadResponse)
+    elif error_v1(response):
+        assert_type(response, img.ImageManagementErrorV1)
+    elif error_v2(response):
+        assert_type(response, img.ImageManagementErrorV2)
+    else:
+        assert_never(response)
+
+
+def _check_write_narrowing() -> None:
+    response = _request(os.EchoWriteRequest(d="hello"))
+    assert_type(response, os.EchoWriteResponse | os.OSManagementErrorV1 | os.OSManagementErrorV2)
+    if success(response):
+        assert_type(response, os.EchoWriteResponse)
+    elif error(response):
+        assert_type(response, os.OSManagementErrorV1 | os.OSManagementErrorV2)
+    else:
+        assert_never(response)
+
+
+def _check_os_reset_binding() -> None:
+    response = _request(os.ResetWriteRequest())
+    assert_type(response, os.ResetWriteResponse | os.OSManagementErrorV1 | os.OSManagementErrorV2)
+
+
+def _check_os_task_stats_binding() -> None:
+    response = _request(os.TaskStatisticsReadRequest())
+    assert_type(
+        response,
+        os.TaskStatisticsReadResponse | os.OSManagementErrorV1 | os.OSManagementErrorV2,
+    )
+
+
+def _check_file_binding() -> None:
+    response = _request(fs.FileDownloadRequest(off=0, name="a"))
+    assert_type(
+        response,
+        fs.FileDownloadResponse | fs.FileSystemManagementErrorV1 | fs.FileSystemManagementErrorV2,
+    )
+
+
+def _check_settings_binding() -> None:
+    response = _request(settings.ReadSettingRequest(name="a"))
+    assert_type(
+        response,
+        settings.ReadSettingResponse
+        | settings.SettingsManagementErrorV1
+        | settings.SettingsManagementErrorV2,
+    )
+
+
+def _check_shell_binding() -> None:
+    response = _request(shell.ExecuteRequest(argv=["a"]))
+    assert_type(
+        response,
+        shell.ExecuteResponse | shell.ShellManagementErrorV1 | shell.ShellManagementErrorV2,
+    )
+
+
+def _check_statistics_binding() -> None:
+    response = _request(stat.GroupDataRequest(name="a"))
+    assert_type(
+        response,
+        stat.GroupDataResponse
+        | stat.StatisticsManagementErrorV1
+        | stat.StatisticsManagementErrorV2,
+    )
+
+
+def _check_enumeration_binding() -> None:
+    response = _request(enum.GroupDetailsRequest())
+    assert_type(
+        response,
+        enum.GroupDetailsResponse | enum.EnumManagementErrorV1 | enum.EnumManagementErrorV2,
+    )
+
+
+def _check_zephyr_binding() -> None:
+    response = _request(zephyr.EraseStorageRequest())
+    assert_type(
+        response,
+        zephyr.EraseStorageResponse
+        | zephyr.ZephyrManagementErrorV1
+        | zephyr.ZephyrManagementErrorV2,
+    )
+
+
+def _check_intercreate_binding() -> None:
+    response = _request(ic.ImageUploadWriteRequest(off=0, data=b""))
+    assert_type(response, ic.ImageUploadWriteResponse | ic.ErrorV1 | ic.ErrorV2)

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -9,28 +9,20 @@ import pytest
 
 from smp import header as smpheader
 from smp import image_management as smpimg
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
+
+imgcmd = smpheader.CommandId.ImageManagement
+IMG = smpheader.GroupId.IMAGE_MANAGEMENT
 
 
 def test_ImageStatesReadRequest() -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.READ,
-        smpheader.CommandId.ImageManagement.STATE,
-        1,  # empty map
+    assert_frame(
+        smpimg.ImageStatesReadRequest(),
+        op=smpheader.OP.READ,
+        group_id=IMG,
+        command_id=imgcmd.STATE,
+        length=1,
     )
-    r = smpimg.ImageStatesReadRequest()
-
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    r = smpimg.ImageStatesReadRequest.loads(r.BYTES)
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    r = smpimg.ImageStatesReadRequest.load(r.header, {})
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
 
 
 @pytest.mark.slow
@@ -56,222 +48,113 @@ def test_ImageStatesReadResponse(
     permanent: bool | None,
     splitStatus: int | None,
 ) -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.READ_RSP,
-        smpheader.CommandId.ImageManagement.STATE,
-        None,
+    image_state = smpimg.ImageState(
+        slot=slot,
+        version=version,
+        image=image,
+        hash=hash,
+        bootable=bootable,
+        pending=pending,
+        confirmed=confirmed,
+        active=active,
+        permanent=permanent,
     )
-    r1 = smpimg.ImageStatesReadResponse(
-        sequence=0,
-        images=[
-            smpimg.ImageState(
-                slot=slot,
-                version=version,
-                image=image,
-                hash=hash,
-                bootable=bootable,
-                pending=pending,
-                confirmed=confirmed,
-                active=active,
-                permanent=permanent,
-            ),
-            smpimg.ImageState(
-                slot=slot,
-                version=version,
-                image=image,
-                hash=hash,
-                bootable=bootable,
-                pending=pending,
-                confirmed=confirmed,
-                active=active,
-                permanent=permanent,
-            ),
-        ],
-        splitStatus=splitStatus,
+    frame = assert_frame(
+        smpimg.ImageStatesReadResponse(images=[image_state, image_state], splitStatus=splitStatus),
+        op=smpheader.OP.READ_RSP,
+        group_id=IMG,
+        command_id=imgcmd.STATE,
     )
 
-    assert_header(r1)
+    payload = cast("dict", cbor2.loads(bytes(frame)[smpheader.Header.SIZE :]))
+    for i, decoded_state in enumerate(frame.data.images):
+        assert decoded_state.slot == slot
+        assert decoded_state.version == version
+        assert decoded_state.image == image
+        assert decoded_state.hash == hash
+        assert decoded_state.bootable == bootable
+        assert decoded_state.pending == pending
+        assert decoded_state.confirmed == confirmed
+        assert decoded_state.active == active
+        assert decoded_state.permanent == permanent
 
-    def assert_response(r: smpimg.ImageStatesReadResponse) -> None:
-        d = cast("dict", cbor2.loads(r.BYTES[8:]))
-        for i, image_state in enumerate(r.images):
-            assert slot == image_state.slot
-            assert version == image_state.version
-            assert image == image_state.image
-            assert hash == image_state.hash
-            assert bootable == image_state.bootable
-            assert pending == image_state.pending
-            assert confirmed == image_state.confirmed
-            assert active == image_state.active
-            assert permanent == image_state.permanent
+        for field in type(decoded_state).__struct_fields__:
+            if getattr(decoded_state, field) is None:
+                assert field not in payload["images"][i]
 
-            for f in type(image_state).model_fields:
-                if getattr(image_state, f) is None:
-                    assert f not in d["images"][i]
-
-        assert splitStatus == r.splitStatus
-
-    assert_response(r1)
-
-    r2 = smpimg.ImageStatesReadResponse.loads(r1.BYTES)
-    assert_header(r2)
-    assert_response(r2)
-
-    r3 = smpimg.ImageStatesReadResponse.load(
-        r1.header, r1.model_dump(exclude={'header', 'sequence'})
-    )
-    assert_header(r3)
-    assert_response(r3)
+    assert frame.data.splitStatus == splitStatus
 
 
 def test_ImageEraseRequest() -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE,
-        smpheader.CommandId.ImageManagement.ERASE,
-        1,  # empty map
+    assert_frame(
+        smpimg.ImageEraseRequest(),
+        op=smpheader.OP.WRITE,
+        group_id=IMG,
+        command_id=imgcmd.ERASE,
+        length=1,
     )
-    r = smpimg.ImageEraseRequest()
 
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    r = smpimg.ImageEraseRequest.loads(r.BYTES)
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    r = smpimg.ImageEraseRequest.load(r.header, {})
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE,
-        smpheader.CommandId.ImageManagement.ERASE,
-        None,
+    frame = assert_frame(
+        smpimg.ImageEraseRequest(slot=0),
+        op=smpheader.OP.WRITE,
+        group_id=IMG,
+        command_id=imgcmd.ERASE,
     )
-    r = smpimg.ImageEraseRequest(slot=0)
-
-    assert_header(r)
-    assert r.slot == 0
-
-    r = smpimg.ImageEraseRequest.loads(r.BYTES)
-    assert_header(r)
-    assert r.slot == 0
+    assert frame.data.slot == 0
 
 
 def test_ImageEraseResponse() -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE_RSP,
-        smpheader.CommandId.ImageManagement.ERASE,
-        1,  # empty map
+    assert_frame(
+        smpimg.ImageEraseResponse(),
+        op=smpheader.OP.WRITE_RSP,
+        group_id=IMG,
+        command_id=imgcmd.ERASE,
+        length=1,
     )
-    r = smpimg.ImageEraseResponse()
-
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    r = smpimg.ImageEraseResponse.loads(r.BYTES)
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
-
-    r = smpimg.ImageEraseResponse.load(r.header, {})
-    assert_header(r)
-    assert len(r.BYTES) == smpheader.Header.SIZE + 1
 
 
 def test_ImageUploadWriteRequest() -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE,
-        smpheader.CommandId.ImageManagement.UPLOAD,
-        None,
+    frame = assert_frame(
+        smpimg.ImageUploadWriteRequest(
+            off=0,
+            data=b"hello",
+            image=1,
+            len=5,
+            sha=b"world",
+            upgrade=True,
+        ),
+        op=smpheader.OP.WRITE,
+        group_id=IMG,
+        command_id=imgcmd.UPLOAD,
     )
-    r = smpimg.ImageUploadWriteRequest(
-        off=0,
-        data=b"hello",
-        image=1,
-        len=5,
-        sha=b"world",
-        upgrade=True,
+    assert frame.data.off == 0
+    assert frame.data.data == b"hello"
+    assert frame.data.image == 1
+    assert frame.data.len == 5
+    assert frame.data.sha == b"world"
+    assert frame.data.upgrade is True
+
+    frame = assert_frame(
+        smpimg.ImageUploadWriteRequest(off=10, data=b"hello"),
+        op=smpheader.OP.WRITE,
+        group_id=IMG,
+        command_id=imgcmd.UPLOAD,
     )
-
-    assert_header(r)
-
-    r = smpimg.ImageUploadWriteRequest.loads(r.BYTES)
-    assert_header(r)
-
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE,
-        smpheader.CommandId.ImageManagement.UPLOAD,
-        None,
-    )
-    r = smpimg.ImageUploadWriteRequest(
-        off=0,
-        data=b"hello",
-        image=1,
-        len=5,
-        sha=b"world",
-        upgrade=True,
-    )
-
-    assert_header(r)
-    assert r.off == 0
-    assert r.data == b"hello"
-    assert r.image == 1
-    assert r.len == 5
-    assert r.sha == b"world"
-    assert r.upgrade is True
-
-    r = smpimg.ImageUploadWriteRequest.loads(r.BYTES)
-    assert_header(r)
-    assert r.off == 0
-    assert r.data == b"hello"
-    assert r.image == 1
-    assert r.len == 5
-    assert r.sha == b"world"
-    assert r.upgrade is True
-
-    # when off != 0 do not send image, len, sha, or upgrade
-    r = smpimg.ImageUploadWriteRequest(off=10, data=b"hello")
-    assert_header(r)
-    assert r.off == 10
-    assert r.data == b"hello"
+    assert frame.data.off == 10
+    assert frame.data.data == b"hello"
 
 
 @pytest.mark.parametrize("off", [None, 0, 1, 0xFFFF, 0xFFFFFFFF])
 @pytest.mark.parametrize("match", [None, True, False])
 def test_ImageUploadWriteResponse(off: int | None, match: bool | None) -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE_RSP,
-        smpheader.CommandId.ImageManagement.UPLOAD,
-        None,
+    frame = assert_frame(
+        smpimg.ImageUploadWriteResponse(off=off, match=match),
+        op=smpheader.OP.WRITE_RSP,
+        group_id=IMG,
+        command_id=imgcmd.UPLOAD,
     )
-    r = smpimg.ImageUploadWriteResponse(off=off, match=match)
-
-    assert_header(r)
-    assert r.off == off
-    assert r.match == match
-
-    r = smpimg.ImageUploadWriteResponse.loads(r.BYTES)
-    assert_header(r)
-    assert r.off == off
-    assert r.match == match
-
-    cbor_dict = (
-        {}
-        | ({"off": off} if off is not None else {})
-        | ({"match": match} if match is not None else {})
-    )
-
-    r = smpimg.ImageUploadWriteResponse.load(r.header, cbor_dict)
-    assert_header(r)
-    assert r.off == off
-    assert r.match == match
+    assert frame.data.off == off
+    assert frame.data.match == match
 
 
 @pytest.mark.parametrize("off", [None, 0, 1, 0xFFFF, 0xFFFFFFFF])
@@ -280,34 +163,12 @@ def test_ImageUploadWriteResponse(off: int | None, match: bool | None) -> None:
 def test_legacy_ImageUploadWriteResponse(
     off: int | None, match: bool | None, rc: int | None
 ) -> None:
-    assert_header = make_assert_header(
-        smpheader.GroupId.IMAGE_MANAGEMENT,
-        smpheader.OP.WRITE_RSP,
-        smpheader.CommandId.ImageManagement.UPLOAD,
-        None,
+    frame = assert_frame(
+        smpimg.ImageUploadWriteResponse(off=off, match=match, rc=rc),
+        op=smpheader.OP.WRITE_RSP,
+        group_id=IMG,
+        command_id=imgcmd.UPLOAD,
     )
-    r = smpimg.ImageUploadWriteResponse(off=off, match=match, rc=rc)
-
-    assert_header(r)
-    assert r.off == off
-    assert r.match == match
-    assert r.rc == rc
-
-    r = smpimg.ImageUploadWriteResponse.loads(r.BYTES)
-    assert_header(r)
-    assert r.off == off
-    assert r.match == match
-    assert r.rc == rc
-
-    cbor_dict = (
-        {}
-        | ({"off": off} if off is not None else {})
-        | ({"match": match} if match is not None else {})
-        | ({"rc": rc} if rc is not None else {})
-    )
-
-    r = smpimg.ImageUploadWriteResponse.load(r.header, cbor_dict)
-    assert_header(r)
-    assert r.off == off
-    assert r.match == match
-    assert r.rc == rc
+    assert frame.data.off == off
+    assert frame.data.match == match
+    assert frame.data.rc == rc

--- a/tests/test_injected_header.py
+++ b/tests/test_injected_header.py
@@ -4,99 +4,67 @@ import pytest
 
 from smp import header as smphdr
 from smp import image_management as smpimg
-from smp.exceptions import SMPMalformed
+from smp.exceptions import SMPMismatchedGroupId
 
 
 def test_ImageUploadWriteRequest_injected_header() -> None:
-    h = smphdr.Header(
+    data = bytes([0x00] * 50)
+
+    header = smphdr.Header(
         op=smphdr.OP.WRITE,
         version=smphdr.Version.V1,
         flags=smphdr.Flag(0),
-        length=0,
+        length=76,
         group_id=smphdr.GroupId.IMAGE_MANAGEMENT,
         sequence=0,
         command_id=smphdr.CommandId.ImageManagement.UPLOAD,
     )
 
-    data = bytes([0x00] * 50)
-
-    r = smpimg.ImageUploadWriteRequest(
-        header=smphdr.Header(
-            op=h.op,
-            version=h.version,
-            flags=h.flags,
-            length=76,
-            group_id=h.group_id,
-            sequence=h.sequence,
-            command_id=h.command_id,
-        ),
-        off=0,
-        data=data,
-        image=1,
-        len=50,
+    frame = smpimg.ImageUploadWriteRequest.load(
+        header, {"off": 0, "data": data, "image": 1, "len": 50}
     )
 
-    assert r.header.length == 76
-    assert len(r.BYTES) == 76 + smphdr.Header.SIZE
+    assert frame.header == header
+    assert frame.header.length == 76
+    assert len(bytes(frame)) == 76 + smphdr.Header.SIZE
+    assert frame.data.off == 0
+    assert frame.data.data == data
+    assert frame.data.image == 1
+    assert frame.data.len == 50
 
-    with pytest.raises(SMPMalformed):
-        r = smpimg.ImageUploadWriteRequest(
-            header=smphdr.Header(
-                op=h.op,
-                version=h.version,
-                flags=h.flags,
-                length=84,
-                group_id=h.group_id,
-                sequence=h.sequence,
-                command_id=h.command_id,
-            ),
-            off=0,
-            data=data,
-            image=1,
-            len=50,
-        )
+    assert smpimg.ImageUploadWriteRequest.loads(bytes(frame)) == frame
 
-    with pytest.raises(SMPMalformed):
-        r = smpimg.ImageUploadWriteRequest(
-            header=smphdr.Header(
-                op=h.op,
-                version=h.version,
-                flags=h.flags,
-                length=0,
-                group_id=h.group_id,
-                sequence=h.sequence,
-                command_id=h.command_id,
+    with pytest.raises(SMPMismatchedGroupId):
+        smpimg.ImageUploadWriteRequest.load(
+            smphdr.Header(
+                op=smphdr.OP.WRITE,
+                version=smphdr.Version.V1,
+                flags=smphdr.Flag(0),
+                length=76,
+                group_id=smphdr.GroupId.OS_MANAGEMENT,
+                sequence=0,
+                command_id=smphdr.CommandId.OSManagement.ECHO,
             ),
-            off=0,
-            data=data,
-            image=1,
-            len=50,
+            {"off": 0, "data": data, "image": 1, "len": 50},
         )
 
 
 def test_ImageUploadWriteResponse_injected_header() -> None:
-    h = smphdr.Header(
+    header = smphdr.Header(
         op=smphdr.OP.WRITE_RSP,
         version=smphdr.Version.V1,
         flags=smphdr.Flag(0),
-        length=0,
+        length=6,
         group_id=smphdr.GroupId.IMAGE_MANAGEMENT,
         sequence=0,
         command_id=smphdr.CommandId.ImageManagement.UPLOAD,
     )
 
-    r = smpimg.ImageUploadWriteResponse(
-        header=smphdr.Header(
-            op=h.op,
-            version=h.version,
-            flags=h.flags,
-            length=6,
-            group_id=h.group_id,
-            sequence=h.sequence,
-            command_id=h.command_id,
-        ),
-        off=0,
-    )
+    frame = smpimg.ImageUploadWriteResponse.load(header, {"off": 0})
 
-    assert r.header.length == 6
-    assert len(r.BYTES) == 6 + smphdr.Header.SIZE
+    assert frame.header == header
+    assert frame.header.length == 6
+    assert len(bytes(frame)) == 6 + smphdr.Header.SIZE
+    assert frame.data.off == 0
+
+    assert smpimg.ImageUploadWriteResponse.loads(bytes(frame)) == frame

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -7,7 +7,10 @@ from typing import Final
 import pytest
 
 from smp import header as smphdr
+from smp import image_management as smpimg
 from smp import message as smpmsg
+from smp import os_management as smpos
+from smp.exceptions import SMPMalformed, SMPMismatchedGroupId
 
 USER_GROUP_ID_MIN: Final = 64
 
@@ -15,7 +18,7 @@ USER_GROUP_ID_MIN: Final = 64
 def test_custom_ReadRequest() -> None:
     """Test ReadRequest inheritance."""
 
-    class A(smpmsg.ReadRequest):
+    class A(smpmsg.ReadRequest, frozen=True):
         _GROUP_ID = USER_GROUP_ID_MIN
         _COMMAND_ID = 0
 
@@ -23,7 +26,7 @@ def test_custom_ReadRequest() -> None:
     assert a._GROUP_ID == USER_GROUP_ID_MIN
     assert a._COMMAND_ID == 0
 
-    class B(smpmsg.ReadRequest):
+    class B(smpmsg.ReadRequest, frozen=True):
         _GROUP_ID = 65
         _COMMAND_ID = 0
 
@@ -35,7 +38,7 @@ def test_custom_ReadRequest() -> None:
         C = 64
         D = 65
 
-    class C(smpmsg.ReadRequest):
+    class C(smpmsg.ReadRequest, frozen=True):
         _GROUP_ID = MyGroupId.C
         _COMMAND_ID = 0
 
@@ -43,7 +46,7 @@ def test_custom_ReadRequest() -> None:
     assert c._GROUP_ID == MyGroupId.C
     assert c._COMMAND_ID == 0
 
-    class D(smpmsg.ReadRequest):
+    class D(smpmsg.ReadRequest, frozen=True):
         _GROUP_ID = MyGroupId.D
         _COMMAND_ID = 0
 
@@ -65,10 +68,10 @@ def test_custom_ReadRequest() -> None:
 )
 @pytest.mark.parametrize("group_id", [USER_GROUP_ID_MIN, 0xFFFF])
 @pytest.mark.parametrize("command_id", [0, 1, 0xFF])
-def test_custom_message(cls: type[smpmsg._MessageBase], group_id: int, command_id: int) -> None:
+def test_custom_message(cls: type[smpmsg.Data], group_id: int, command_id: int) -> None:
     """Test ReadRequest inheritance."""
 
-    class CustomInts(cls):  # type: ignore
+    class CustomInts(cls):  # type: ignore[valid-type, misc]
         _OP = getattr(cls, "_OP", smphdr.OP.READ)
         _GROUP_ID = group_id
         _COMMAND_ID = command_id
@@ -81,38 +84,47 @@ def test_custom_message(cls: type[smpmsg._MessageBase], group_id: int, command_i
 def test_invalid_group_id() -> None:
     """Test invalid group_id."""
 
-    with pytest.raises(struct.error):
-
-        class A(smpmsg.ReadRequest):
-            _GROUP_ID = 0x10000
-            _COMMAND_ID = 0
-
-        A()
+    class A(smpmsg.ReadRequest, frozen=True):
+        _GROUP_ID = 0x10000
+        _COMMAND_ID = 0
 
     with pytest.raises(struct.error):
+        A().to_frame(sequence=0)
 
-        class B(smpmsg.ReadRequest):
-            _GROUP_ID = -1
-            _COMMAND_ID = 0
+    class B(smpmsg.ReadRequest, frozen=True):
+        _GROUP_ID = -1
+        _COMMAND_ID = 0
 
-        B()
+    with pytest.raises(struct.error):
+        B().to_frame(sequence=0)
 
 
 def test_invalid_command_id() -> None:
     """Test invalid command_id."""
 
-    with pytest.raises(struct.error):
-
-        class A(smpmsg.ReadRequest):
-            _GROUP_ID = USER_GROUP_ID_MIN
-            _COMMAND_ID = 0x100
-
-        A()
+    class A(smpmsg.ReadRequest, frozen=True):
+        _GROUP_ID = USER_GROUP_ID_MIN
+        _COMMAND_ID = 0x100
 
     with pytest.raises(struct.error):
+        A().to_frame(sequence=0)
 
-        class B(smpmsg.ReadRequest):
-            _GROUP_ID = USER_GROUP_ID_MIN
-            _COMMAND_ID = -1
+    class B(smpmsg.ReadRequest, frozen=True):
+        _GROUP_ID = USER_GROUP_ID_MIN
+        _COMMAND_ID = -1
 
-        B()
+    with pytest.raises(struct.error):
+        B().to_frame(sequence=0)
+
+
+def test_loads_rejects_mismatched_group_id() -> None:
+    wire = bytes(smpimg.ImageStatesReadRequest().to_frame(sequence=0))
+    with pytest.raises(SMPMismatchedGroupId):
+        smpos.EchoWriteResponse.loads(wire)
+
+
+def test_loads_rejects_length_mismatch() -> None:
+    wire = bytearray(bytes(smpimg.ImageStatesReadRequest().to_frame(sequence=0)))
+    wire[2:4] = b"\xff\xff"  # corrupt the header length field
+    with pytest.raises(SMPMalformed):
+        smpimg.ImageStatesReadRequest.loads(bytes(wire))

--- a/tests/test_os_management.py
+++ b/tests/test_os_management.py
@@ -1,381 +1,408 @@
-"""Test the SMP Image Management group."""
+"""Test the SMP OS Management group."""
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
-
-import cbor2
+import msgspec
 import pytest
-from pydantic import BaseModel, ValidationError
 
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import os_management as smpos
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
 
 oscmd = smphdr.CommandId.OSManagement
-
-
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.OSManagement,
-    data: dict[str, Any],
-    nested_model: type[BaseModel] | None = None,
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.OS_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            if type(v) is dict and nested_model is not None:
-                for k2, v2 in v.items():
-                    one_deep = getattr(r, k)
-                    assert isinstance(one_deep[k2], nested_model)
-                    assert v2 == one_deep[k2].model_dump()
-            else:
-                assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+OS = smphdr.GroupId.OS_MANAGEMENT
 
 
 def test_EchoWriteRequest() -> None:
-    _do_test(
-        smpos.EchoWriteRequest,
-        smphdr.OP.WRITE,
-        oscmd.ECHO,
-        {"d": "Hello world!"},
+    assert_frame(
+        smpos.EchoWriteRequest(d="Hello world!"),
+        op=smphdr.OP.WRITE,
+        group_id=OS,
+        command_id=oscmd.ECHO,
     )
 
 
 def test_EchoWriteResponse() -> None:
-    _do_test(
-        smpos.EchoWriteResponse,
-        smphdr.OP.WRITE_RSP,
-        oscmd.ECHO,
-        {"r": "Hi!"},
+    assert_frame(
+        smpos.EchoWriteResponse(r="Hi!"), op=smphdr.OP.WRITE_RSP, group_id=OS, command_id=oscmd.ECHO
     )
 
 
 def test_ResetWriteRequest() -> None:
-    _do_test(smpos.ResetWriteRequest, smphdr.OP.WRITE, oscmd.RESET, {})
+    assert_frame(
+        smpos.ResetWriteRequest(), op=smphdr.OP.WRITE, group_id=OS, command_id=oscmd.RESET, length=1
+    )
 
 
 def test_ResetWriteResponse() -> None:
-    _do_test(smpos.ResetWriteResponse, smphdr.OP.WRITE_RSP, oscmd.RESET, {})
+    assert_frame(
+        smpos.ResetWriteResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=OS,
+        command_id=oscmd.RESET,
+        length=1,
+    )
 
 
 def test_ResetWriteRequest_boot_mode_normal() -> None:
-    r = _do_test(smpos.ResetWriteRequest, smphdr.OP.WRITE, oscmd.RESET, {"boot_mode": 0})
-    assert r.boot_mode is smpos.BootMode.NORMAL
+    frame = assert_frame(
+        smpos.ResetWriteRequest(boot_mode=0),
+        op=smphdr.OP.WRITE,
+        group_id=OS,
+        command_id=oscmd.RESET,
+    )
+    assert frame.data.boot_mode is smpos.BootMode.NORMAL
 
 
 def test_ResetWriteRequest_boot_mode_bootloader() -> None:
-    r = _do_test(smpos.ResetWriteRequest, smphdr.OP.WRITE, oscmd.RESET, {"boot_mode": 1})
-    assert r.boot_mode is smpos.BootMode.BOOTLOADER
+    frame = assert_frame(
+        smpos.ResetWriteRequest(boot_mode=1),
+        op=smphdr.OP.WRITE,
+        group_id=OS,
+        command_id=oscmd.RESET,
+    )
+    assert frame.data.boot_mode is smpos.BootMode.BOOTLOADER
 
 
 def test_ResetWriteRequest_boot_mode_passes_through_unknown_int() -> None:
     """A wire-valid but unrecognized boot mode stays a plain int."""
-    r = _do_test(smpos.ResetWriteRequest, smphdr.OP.WRITE, oscmd.RESET, {"boot_mode": 5})
-    assert r.boot_mode == 5
-    assert type(r.boot_mode) is int
+    frame = assert_frame(
+        smpos.ResetWriteRequest(boot_mode=5),
+        op=smphdr.OP.WRITE,
+        group_id=OS,
+        command_id=oscmd.RESET,
+    )
+    assert frame.data.boot_mode == 5
+    assert type(frame.data.boot_mode) is int
 
 
 def test_ResetWriteRequest_force_and_boot_mode() -> None:
-    r = _do_test(
-        smpos.ResetWriteRequest,
-        smphdr.OP.WRITE,
-        oscmd.RESET,
-        {"force": 1, "boot_mode": 1},
+    frame = assert_frame(
+        smpos.ResetWriteRequest(force=1, boot_mode=1),
+        op=smphdr.OP.WRITE,
+        group_id=OS,
+        command_id=oscmd.RESET,
     )
-    assert r.force == 1
-    assert r.boot_mode is smpos.BootMode.BOOTLOADER
+    assert frame.data.force == 1
+    assert frame.data.boot_mode is smpos.BootMode.BOOTLOADER
 
 
 def test_ResetWriteRequest_boot_mode_accepts_enum_member() -> None:
     """Constructing with a BootMode member serializes identically to its int value."""
     from_enum = smpos.ResetWriteRequest(boot_mode=smpos.BootMode.BOOTLOADER)
     from_int = smpos.ResetWriteRequest(boot_mode=1)
-    assert from_enum.BYTES[8:] == from_int.BYTES[8:]
+    assert bytes(from_enum.to_frame(sequence=0))[8:] == bytes(from_int.to_frame(sequence=0))[8:]
     assert from_enum.boot_mode is smpos.BootMode.BOOTLOADER
 
 
 @pytest.mark.parametrize("boot_mode", [-1, 256])
 def test_ResetWriteRequest_boot_mode_rejects_out_of_range(boot_mode: int) -> None:
     """boot_mode is a uint8_t on the wire; values outside [0, 255] are invalid."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         smpos.ResetWriteRequest(boot_mode=boot_mode)
 
 
 def test_TaskStatisticsReadRequest() -> None:
-    _do_test(smpos.TaskStatisticsReadRequest, smphdr.OP.READ, oscmd.TASK_STATS, {})
+    assert_frame(
+        smpos.TaskStatisticsReadRequest(),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.TASK_STATS,
+        length=1,
+    )
 
 
 def test_TaskStatisticsReadResponse() -> None:
-    m = _do_test(
-        smpos.TaskStatisticsReadResponse,
-        smphdr.OP.READ_RSP,
-        oscmd.TASK_STATS,
-        {
-            "tasks": {
-                "task_1": {
-                    "prio": 1,
-                    "tid": 2,
-                    "state": 3,
-                    "stkuse": 4,
-                    "stksiz": 5,
-                    "cswcnt": 6,
-                    "runtime": 7,
-                    "last_checkin": 0,
-                    "next_checkin": 0,
-                },
-                "task_2": {
-                    "prio": 8,
-                    "tid": 9,
-                    "state": 10,
-                    "stkuse": 11,
-                    "stksiz": 12,
-                    "cswcnt": 13,
-                    "runtime": 14,
-                    "last_checkin": 0,
-                    "next_checkin": 0,
-                },
+    frame = assert_frame(
+        smpos.TaskStatisticsReadResponse(
+            tasks={
+                "task_1": smpos.TaskStatistics(
+                    prio=1,
+                    tid=2,
+                    state=3,
+                    stkuse=4,
+                    stksiz=5,
+                    cswcnt=6,
+                    runtime=7,
+                    last_checkin=0,
+                    next_checkin=0,
+                ),
+                "task_2": smpos.TaskStatistics(
+                    prio=8,
+                    tid=9,
+                    state=10,
+                    stkuse=11,
+                    stksiz=12,
+                    cswcnt=13,
+                    runtime=14,
+                    last_checkin=0,
+                    next_checkin=0,
+                ),
             }
-        },
-        nested_model=smpos.TaskStatistics,
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.TASK_STATS,
     )
-
-    assert m.tasks["task_1"].prio == 1
-    assert m.tasks["task_2"].prio == 8
-    assert m.tasks["task_1"].tid == 2
-    assert m.tasks["task_2"].tid == 9
+    assert frame.data.tasks["task_1"].prio == 1
+    assert frame.data.tasks["task_2"].prio == 8
+    assert frame.data.tasks["task_1"].tid == 2
+    assert frame.data.tasks["task_2"].tid == 9
 
 
 def test_MemoryPoolStatisticsReadRequest() -> None:
-    _do_test(smpos.MemoryPoolStatisticsReadRequest, smphdr.OP.READ, oscmd.MEMORY_POOL_STATS, {})
-
-
-def test_MemoryPoolStatisticsReadResponse() -> None:
-    _do_test(
-        smpos.MemoryPoolStatisticsReadResponse,
-        smphdr.OP.READ_RSP,
-        oscmd.MEMORY_POOL_STATS,
-        {
-            "mem_pool_1": {"blksize": 1, "nblks": 2, "nfree": 3, "min": 4},
-            "mem_pool_2": {"blksize": 5, "nblks": 6, "nfree": 7, "min": 8},
-        },
+    assert_frame(
+        smpos.MemoryPoolStatisticsReadRequest(),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.MEMORY_POOL_STATS,
+        length=1,
     )
 
 
+def test_MemoryPoolStatisticsReadResponse() -> None:
+    frame = assert_frame(
+        smpos.MemoryPoolStatisticsReadResponse(
+            pools={
+                "mem_pool_1": smpos.MemoryPoolStatistics(blksize=1, nblks=2, nfree=3, min=4),
+                "mem_pool_2": smpos.MemoryPoolStatistics(blksize=5, nblks=6, nfree=7, min=8),
+            }
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.MEMORY_POOL_STATS,
+    )
+    assert frame.data.pools["mem_pool_1"].blksize == 1
+    assert frame.data.pools["mem_pool_2"].min == 8
+
+
 def test_DatetimeReadRequest() -> None:
-    _do_test(smpos.DateTimeReadRequest, smphdr.OP.READ, oscmd.DATETIME_STRING, {})
+    assert_frame(
+        smpos.DateTimeReadRequest(),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.DATETIME_STRING,
+        length=1,
+    )
 
 
 def test_DatetimeReadResponse() -> None:
-    _do_test(
-        smpos.DateTimeReadResponse,
-        smphdr.OP.READ_RSP,
-        oscmd.DATETIME_STRING,
-        {"datetime": "2024-01-01T00:00:00Z"},
+    assert_frame(
+        smpos.DateTimeReadResponse(datetime="2024-01-01T00:00:00Z"),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.DATETIME_STRING,
     )
 
 
 def test_DateTimeWriteRequest() -> None:
-    _do_test(
-        smpos.DateTimeWriteRequest,
-        smphdr.OP.WRITE,
-        oscmd.DATETIME_STRING,
-        {"datetime": "2024-01-01T00:00:00Z"},
+    assert_frame(
+        smpos.DateTimeWriteRequest(datetime="2024-01-01T00:00:00Z"),
+        op=smphdr.OP.WRITE,
+        group_id=OS,
+        command_id=oscmd.DATETIME_STRING,
     )
 
 
 def test_DateTimeWriteResponse() -> None:
-    _do_test(
-        smpos.DateTimeWriteResponse,
-        smphdr.OP.WRITE_RSP,
-        oscmd.DATETIME_STRING,
-        {},
+    assert_frame(
+        smpos.DateTimeWriteResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=OS,
+        command_id=oscmd.DATETIME_STRING,
+        length=1,
     )
 
 
 def test_MCUMgrParametersReadRequest() -> None:
-    _do_test(smpos.MCUMgrParametersReadRequest, smphdr.OP.READ, oscmd.MCUMGR_PARAMETERS, {})
-
-
-def test_MCUMgrParametersReadResponse() -> None:
-    _do_test(
-        smpos.MCUMgrParametersReadResponse,
-        smphdr.OP.READ_RSP,
-        oscmd.MCUMGR_PARAMETERS,
-        {"buf_size": 1, "buf_count": 2},
+    assert_frame(
+        smpos.MCUMgrParametersReadRequest(),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.MCUMGR_PARAMETERS,
+        length=1,
     )
 
 
+def test_MCUMgrParametersReadResponse() -> None:
+    frame = assert_frame(
+        smpos.MCUMgrParametersReadResponse(buf_size=1, buf_count=2),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.MCUMGR_PARAMETERS,
+    )
+    assert frame.data.buf_size == 1
+    assert frame.data.buf_count == 2
+
+
 def test_OSApplicationInfoReadRequest() -> None:
-    _do_test(smpos.OSApplicationInfoReadRequest, smphdr.OP.READ, oscmd.OS_APPLICATION_INFO, {})
-    _do_test(
-        smpos.OSApplicationInfoReadRequest,
-        smphdr.OP.READ,
-        oscmd.OS_APPLICATION_INFO,
-        {"format": "snrvbmpioa"},
+    assert_frame(
+        smpos.OSApplicationInfoReadRequest(),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.OS_APPLICATION_INFO,
+        length=1,
+    )
+    assert_frame(
+        smpos.OSApplicationInfoReadRequest(format="snrvbmpioa"),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.OS_APPLICATION_INFO,
     )
 
 
 def test_OSApplicationInfoReadResponse() -> None:
-    _do_test(
-        smpos.OSApplicationInfoReadResponse,
-        smphdr.OP.READ_RSP,
-        oscmd.OS_APPLICATION_INFO,
-        {"output": "the requested output string"},
+    assert_frame(
+        smpos.OSApplicationInfoReadResponse(output="the requested output string"),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.OS_APPLICATION_INFO,
     )
 
 
 def test_BootloaderInformationReadRequest() -> None:
-    _do_test(smpos.BootloaderInformationReadRequest, smphdr.OP.READ, oscmd.BOOTLOADER_INFO, {})
-    _do_test(
-        smpos.BootloaderInformationReadRequest,
-        smphdr.OP.READ,
-        oscmd.BOOTLOADER_INFO,
-        {"query": "MCUbootMode"},
+    assert_frame(
+        smpos.BootloaderInformationReadRequest(),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.BOOTLOADER_INFO,
+        length=1,
+    )
+    assert_frame(
+        smpos.BootloaderInformationReadRequest(query="MCUbootMode"),
+        op=smphdr.OP.READ,
+        group_id=OS,
+        command_id=oscmd.BOOTLOADER_INFO,
     )
 
 
 def test_BootloaderInformationReadResponse() -> None:
-    r = _do_test(
-        smpos.BootloaderInformationReadResponse,
-        smphdr.OP.READ_RSP,
-        oscmd.BOOTLOADER_INFO,
-        {"bootloader": "MCUboot", "response": {"mode": 3, "no-downgrade": True}},
+    frame = assert_frame(
+        smpos.BootloaderInformationReadResponse(
+            bootloader="MCUboot",
+            response=smpos.MCUbootModeQueryResponse(
+                mode=smpos.MCUbootMode.SWAP_WITHOUT_SCRATCH, no_downgrade=True
+            ),
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.BOOTLOADER_INFO,
     )
-
-    assert r.bootloader == "MCUboot"
-    assert type(r.response) is dict
-    assert r.response["mode"] == smpos.MCUbootMode.SWAP_WITHOUT_SCRATCH
-    assert r.response["no-downgrade"] is True
+    assert frame.data.bootloader == "MCUboot"
+    assert type(frame.data.response) is smpos.MCUbootModeQueryResponse
+    assert frame.data.response.mode is smpos.MCUbootMode.SWAP_WITHOUT_SCRATCH
+    assert frame.data.response.no_downgrade is True
 
 
 def test_TaskStatisticsReadResponse_all_fields() -> None:
     """Test TaskStatistics with all fields present."""
-    data: dict[str, Any] = {
-        "tasks": {
-            "task": {
-                "prio": 1,
-                "tid": 2,
-                "state": 3,
-                "stkuse": 4,
-                "stksiz": 5,
-                "cswcnt": 6,
-                "runtime": 7,
-                "last_checkin": 0,
-                "next_checkin": 0,
+    frame = assert_frame(
+        smpos.TaskStatisticsReadResponse(
+            tasks={
+                "task": smpos.TaskStatistics(
+                    prio=1,
+                    tid=2,
+                    state=3,
+                    stkuse=4,
+                    stksiz=5,
+                    cswcnt=6,
+                    runtime=7,
+                    last_checkin=0,
+                    next_checkin=0,
+                )
             }
-        }
-    }
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.OS_MANAGEMENT, smphdr.OP.READ_RSP, oscmd.TASK_STATS, len(cbor)
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.TASK_STATS,
     )
-
-    m = smpos.TaskStatisticsReadResponse(**data)
-    assert_header(m)
-    assert isinstance(m.tasks["task"], smpos.TaskStatistics)
-    assert m.tasks["task"].prio == 1
-    assert m.tasks["task"].tid == 2
-    assert m.tasks["task"].state == 3
-    assert m.tasks["task"].stkuse == 4
-    assert m.tasks["task"].stksiz == 5
-    assert m.tasks["task"].cswcnt == 6
-    assert m.tasks["task"].runtime == 7
-    assert m.tasks["task"].last_checkin == 0
-    assert m.tasks["task"].next_checkin == 0
-    assert cbor == m.BYTES[8:]
-
-    # Test deserialization
-    m2 = smpos.TaskStatisticsReadResponse.loads(m.BYTES)
-    assert_header(m2)
-    assert isinstance(m2.tasks["task"], smpos.TaskStatistics)
+    task = frame.data.tasks["task"]
+    assert isinstance(task, smpos.TaskStatistics)
+    assert task.prio == 1
+    assert task.tid == 2
+    assert task.state == 3
+    assert task.stkuse == 4
+    assert task.stksiz == 5
+    assert task.cswcnt == 6
+    assert task.runtime == 7
+    assert task.last_checkin == 0
+    assert task.next_checkin == 0
 
 
 def test_TaskStatisticsZephyrReadResponse_only_required() -> None:
     """Test TaskStatisticsZephyr with only required fields (prio, tid, state)."""
-    data: dict[str, Any] = {
-        "tasks": {
-            "zephyr_task": {
-                "prio": 10,
-                "tid": 20,
-                "state": 30,
-            }
-        }
-    }
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.OS_MANAGEMENT, smphdr.OP.READ_RSP, oscmd.TASK_STATS, len(cbor)
+    frame = assert_frame(
+        smpos.TaskStatisticsReadResponse(
+            tasks={"zephyr_task": smpos.TaskStatisticsZephyr(prio=10, tid=20, state=30)}
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.TASK_STATS,
     )
-
-    m = smpos.TaskStatisticsReadResponse(**data)
-    assert_header(m)
-    assert isinstance(m.tasks["zephyr_task"], smpos.TaskStatisticsZephyr)
-    assert m.tasks["zephyr_task"].prio == 10
-    assert m.tasks["zephyr_task"].tid == 20
-    assert m.tasks["zephyr_task"].state == 30
-    assert m.tasks["zephyr_task"].stkuse is None
-    assert m.tasks["zephyr_task"].stksiz is None
-    assert m.tasks["zephyr_task"].cswcnt is None
-    assert m.tasks["zephyr_task"].runtime is None
-    assert m.tasks["zephyr_task"].last_checkin is None
-    assert m.tasks["zephyr_task"].next_checkin is None
-    assert cbor == m.BYTES[8:]
-
-    # Test deserialization
-    m2 = smpos.TaskStatisticsReadResponse.loads(m.BYTES)
-    assert_header(m2)
-    assert isinstance(m2.tasks["zephyr_task"], smpos.TaskStatisticsZephyr)
+    task = frame.data.tasks["zephyr_task"]
+    assert isinstance(task, smpos.TaskStatisticsZephyr)
+    assert task.prio == 10
+    assert task.tid == 20
+    assert task.state == 30
+    assert task.stkuse is None
+    assert task.stksiz is None
+    assert task.cswcnt is None
+    assert task.runtime is None
+    assert task.last_checkin is None
+    assert task.next_checkin is None
 
 
 def test_TaskStatisticsZephyrReadResponse_partial_fields() -> None:
     """Test TaskStatisticsZephyr with some optional fields present."""
-    data: dict[str, Any] = {
-        "tasks": {
-            "partial_task": {
-                "prio": 5,
-                "tid": 15,
-                "state": 25,
-                "stksiz": 100,
-                "stkuse": 50,
+    frame = assert_frame(
+        smpos.TaskStatisticsReadResponse(
+            tasks={
+                "partial_task": smpos.TaskStatisticsZephyr(
+                    prio=5, tid=15, state=25, stksiz=100, stkuse=50
+                )
             }
-        }
-    }
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.OS_MANAGEMENT, smphdr.OP.READ_RSP, oscmd.TASK_STATS, len(cbor)
+        ),
+        op=smphdr.OP.READ_RSP,
+        group_id=OS,
+        command_id=oscmd.TASK_STATS,
+    )
+    task = frame.data.tasks["partial_task"]
+    assert isinstance(task, smpos.TaskStatisticsZephyr)
+    assert task.prio == 5
+    assert task.tid == 15
+    assert task.state == 25
+    assert task.stksiz == 100
+    assert task.stkuse == 50
+    assert task.cswcnt is None
+    assert task.runtime is None
+    assert task.last_checkin is None
+    assert task.next_checkin is None
+
+
+def _os_header(command_id: smphdr.CommandId.OSManagement, op: smphdr.OP) -> smphdr.Header:
+    return smphdr.Header(
+        op=op,
+        version=smphdr.Version.V2,
+        flags=smphdr.Flag(0),
+        length=0,
+        group_id=OS,
+        sequence=0,
+        command_id=command_id,
     )
 
-    m = smpos.TaskStatisticsReadResponse(**data)
-    assert_header(m)
-    assert isinstance(m.tasks["partial_task"], smpos.TaskStatisticsZephyr)
-    assert m.tasks["partial_task"].prio == 5
-    assert m.tasks["partial_task"].tid == 15
-    assert m.tasks["partial_task"].state == 25
-    assert m.tasks["partial_task"].stksiz == 100
-    assert m.tasks["partial_task"].stkuse == 50
-    assert m.tasks["partial_task"].cswcnt is None
-    assert m.tasks["partial_task"].runtime is None
-    assert m.tasks["partial_task"].last_checkin is None
-    assert m.tasks["partial_task"].next_checkin is None
-    assert cbor == m.BYTES[8:]
 
-    # Test deserialization
-    m2 = smpos.TaskStatisticsReadResponse.loads(m.BYTES)
-    assert_header(m2)
-    assert isinstance(m2.tasks["partial_task"], smpos.TaskStatisticsZephyr)
+def test_TaskStatisticsReadResponse_rejects_missing_tasks() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpos.TaskStatisticsReadResponse.load(_os_header(oscmd.TASK_STATS, smphdr.OP.READ_RSP), {})
+
+
+def test_TaskStatisticsReadResponse_rejects_non_map_tasks() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpos.TaskStatisticsReadResponse.load(
+            _os_header(oscmd.TASK_STATS, smphdr.OP.READ_RSP), {"tasks": 5}
+        )
+
+
+def test_ResetWriteRequest_rejects_unknown_field() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        smpos.ResetWriteRequest.load(_os_header(oscmd.RESET, smphdr.OP.WRITE), {"bogus": 1})

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -3,9 +3,9 @@
 import struct
 from base64 import b64decode
 
+import msgspec
 import pytest
 from crcmod.predefined import mkPredefinedCrcFun  # type: ignore
-from pydantic import ValidationError
 
 from smp import header, image_management
 from smp.exceptions import SMPBadContinueDelimiter, SMPBadCRC, SMPBadStartDelimiter
@@ -33,7 +33,7 @@ def _assert_header(frame: bytes) -> None:
 
 def _assert_payload(frame: bytes, data: bytes) -> None:
     # deserialize the original request itself
-    r = image_management.ImageUploadWriteRequest.loads(frame)
+    r = image_management.ImageUploadWriteRequest.loads(frame).data
     assert off == r.off
     assert image == r.image
     assert length == r.len
@@ -56,7 +56,7 @@ def test_encode(line_length: int, line_length_ratio: float) -> None:
     )
 
     reconstruct = bytearray([])
-    for i, p in enumerate(encode(r.BYTES, line_length=line_length)):
+    for i, p in enumerate(encode(bytes(r.to_frame(sequence=0)), line_length=line_length)):
         # assert that packet delimiters are correct
         if i == 0:
             assert bytes([6, 9]) == p[:2]
@@ -96,7 +96,7 @@ def test_decode(line_length: int, line_length_ratio: float) -> None:
         off=off, data=data, image=image, len=length, sha=sha, upgrade=upgrade
     )
     packets = []
-    for p in encode(req.BYTES, line_length=line_length):
+    for p in encode(bytes(req.to_frame(sequence=0)), line_length=line_length):
         packets.append(p)
 
     decoder = decode()
@@ -119,7 +119,7 @@ def test_decode_raises_SMPBadStartDelimiter() -> None:
         off=off, data=b"hello!", image=image, len=length, sha=sha, upgrade=upgrade
     )
     packets = []
-    for p in encode(req.BYTES):
+    for p in encode(bytes(req.to_frame(sequence=0))):
         packets.append(p)
 
     # malform the start delimiter
@@ -149,7 +149,7 @@ def test_decode_raises_SMPBadContinueDelimiter() -> None:
         upgrade=upgrade,
     )
     packets = []
-    for p in encode(req.BYTES, line_length=line_length):
+    for p in encode(bytes(req.to_frame(sequence=0)), line_length=line_length):
         packets.append(p)
 
     assert len(packets) > 1
@@ -184,7 +184,7 @@ def test_decode_raises_SMPBadCRC(j: int, i: int) -> None:
     )
 
     packets = []
-    for p in encode(req.BYTES, line_length=line_length):
+    for p in encode(bytes(req.to_frame(sequence=0)), line_length=line_length):
         packets.append(p)
 
     assert len(packets) == 4
@@ -200,7 +200,7 @@ def test_decode_raises_SMPBadCRC(j: int, i: int) -> None:
         decoder = decode()
         next(decoder)
 
-        with pytest.raises((SMPBadCRC, ValidationError)):
+        with pytest.raises((SMPBadCRC, msgspec.DecodeError)):
             frame = b""
             for packet in packets:
                 try:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,11 +2,14 @@
 
 from typing import Final
 
+import cbor2
 import msgspec
 import pytest
 
 import smp.header as smphdr
 import smp.image_management as smpimg
+import smp.message as smpmsg
+from tests.helpers import assert_frame
 
 
 def test_smpclient_41() -> None:
@@ -33,3 +36,53 @@ def test_smpclient_41() -> None:
 
     with pytest.raises((msgspec.ValidationError, KeyError)):
         smpimg.ImageManagementErrorV2.loads(RESPONSE)
+
+
+def test_smp_45() -> None:
+    """https://github.com/JPHutchins/smp/issues/45
+
+    An SMP message's CBOR payload may legitimately contain fields named
+    `header`, `version`, `sequence`, or `smp_data`. The flattened pre-`Frame`
+    design excluded those names from serialization, silently dropping them; the
+    payload is now a distinct `Data` struct, so the names survive a round trip.
+    """
+
+    USER_GROUP: Final = 0x1234
+    COLLIDING: Final = {"header", "version", "sequence", "smp_data"}
+
+    class CollidingReadResponse(smpmsg.ReadResponse, frozen=True):
+        _GROUP_ID = USER_GROUP
+        _COMMAND_ID = 0
+
+        header: int
+        version: str
+        sequence: int
+        smp_data: bytes
+
+    response = CollidingReadResponse(header=1, version="1.2.3", sequence=7, smp_data=b"\xde\xad")
+    assert set(cbor2.loads(bytes(response))) == COLLIDING
+
+    decoded = assert_frame(response, op=smphdr.OP.READ_RSP, group_id=USER_GROUP, command_id=0)
+    assert decoded.data == response
+    assert decoded.data.header == 1
+    assert decoded.data.version == "1.2.3"
+    assert decoded.data.sequence == 7
+    assert decoded.data.smp_data == b"\xde\xad"
+
+    assert decoded.header.version == smphdr.Version.V2
+    assert decoded.header.sequence == 0
+
+    class CollidingWriteRequest(smpmsg.WriteRequest, frozen=True):
+        _GROUP_ID = USER_GROUP
+        _COMMAND_ID = 0
+
+        header: int
+        version: str
+        sequence: int
+        smp_data: bytes
+
+    request = CollidingWriteRequest(header=2, version="4.5.6", sequence=9, smp_data=b"\xbe\xef")
+    assert set(cbor2.loads(bytes(request))) == COLLIDING
+    assert (
+        assert_frame(request, op=smphdr.OP.WRITE, group_id=USER_GROUP, command_id=0).data == request
+    )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,6 +2,7 @@
 
 from typing import Final
 
+import msgspec
 import pytest
 
 import smp.header as smphdr
@@ -14,21 +15,21 @@ def test_smpclient_41() -> None:
     RESPONSE: Final = b"\x03\x00\x00\x0c\x00\x01\x02\x01\xbfbrc\x00coff\x18\xa5\xff"
     """A legacy `ImageUploadWriteResponse` that contains the rc field."""
 
-    r: Final = smpimg.ImageUploadWriteResponse.loads(RESPONSE)
+    frame: Final = smpimg.ImageUploadWriteResponse.loads(RESPONSE)
 
-    assert r.header.op == smphdr.OP.WRITE_RSP
-    assert r.header.version == smphdr.Version.V1
-    assert r.header.flags == smphdr.Flag(0)
-    assert r.header.length == 12
-    assert r.header.group_id == smphdr.GroupId.IMAGE_MANAGEMENT
-    assert r.header.sequence == 2
-    assert r.header.command_id == smphdr.CommandId.ImageManagement.UPLOAD
+    assert frame.header.op == smphdr.OP.WRITE_RSP
+    assert frame.header.version == smphdr.Version.V1
+    assert frame.header.flags == smphdr.Flag(0)
+    assert frame.header.length == 12
+    assert frame.header.group_id == smphdr.GroupId.IMAGE_MANAGEMENT
+    assert frame.header.sequence == 2
+    assert frame.header.command_id == smphdr.CommandId.ImageManagement.UPLOAD
 
-    assert r.off == 165
-    assert r.rc == 0
+    assert frame.data.off == 165
+    assert frame.data.rc == 0
 
-    with pytest.raises(ValueError):
+    with pytest.raises(msgspec.ValidationError):
         smpimg.ImageManagementErrorV1.loads(RESPONSE)
 
-    with pytest.raises(ValueError):
+    with pytest.raises((msgspec.ValidationError, KeyError)):
         smpimg.ImageManagementErrorV2.loads(RESPONSE)

--- a/tests/test_settings_management.py
+++ b/tests/test_settings_management.py
@@ -2,171 +2,141 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import settings_management as smpset
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.SettingsManagement,
-    data: dict[str, Any],
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.SETTINGS_MANAGEMENT, op, command_id, len(cbor)
-    )
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+setcmd = smphdr.CommandId.SettingsManagement
 
 
 def test_ReadSettingRequest() -> None:
-    r = _do_test(
-        smpset.ReadSettingRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING,
-        {"name": "example"},
+    frame = assert_frame(
+        smpset.ReadSettingRequest(name="example"),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.READ_WRITE_SETTING,
     )
-    assert r.name == "example"
-    assert r.max_size is None
+    assert frame.data.name == "example"
+    assert frame.data.max_size is None
 
-    r = _do_test(
-        smpset.ReadSettingRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING,
-        {"name": "example", "max_size": 256},
+    frame = assert_frame(
+        smpset.ReadSettingRequest(name="example", max_size=256),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.READ_WRITE_SETTING,
     )
-    assert r.name == "example"
-    assert r.max_size == 256
+    assert frame.data.name == "example"
+    assert frame.data.max_size == 256
 
 
 def test_ReadSettingResponse() -> None:
-    r = _do_test(
-        smpset.ReadSettingResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING,
-        {"val": b"example"},
+    frame = assert_frame(
+        smpset.ReadSettingResponse(val=b"example"),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.READ_WRITE_SETTING,
     )
-    assert r.val == b"example"
-    assert r.max_size is None
+    assert frame.data.val == b"example"
+    assert frame.data.max_size is None
 
-    r = _do_test(
-        smpset.ReadSettingResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING,
-        {"val": b"example", "max_size": 256},
+    frame = assert_frame(
+        smpset.ReadSettingResponse(val=b"example", max_size=256),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.READ_WRITE_SETTING,
     )
-    assert r.val == b"example"
-    assert r.max_size == 256
+    assert frame.data.val == b"example"
+    assert frame.data.max_size == 256
 
 
 def test_WriteSettingRequest() -> None:
-    r = _do_test(
-        smpset.WriteSettingRequest,
-        smphdr.OP.WRITE,
-        smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING,
-        {"name": "example", "val": b"example"},
+    frame = assert_frame(
+        smpset.WriteSettingRequest(name="example", val=b"example"),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.READ_WRITE_SETTING,
     )
-    assert r.name == "example"
-    assert r.val == b"example"
+    assert frame.data.name == "example"
+    assert frame.data.val == b"example"
 
 
 def test_WriteSettingResponse() -> None:
-    _do_test(
-        smpset.WriteSettingResponse,
-        smphdr.OP.WRITE_RSP,
-        smphdr.CommandId.SettingsManagement.READ_WRITE_SETTING,
-        {},
+    assert_frame(
+        smpset.WriteSettingResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.READ_WRITE_SETTING,
     )
 
 
 def test_DeleteSettingRequest() -> None:
-    r = _do_test(
-        smpset.DeleteSettingRequest,
-        smphdr.OP.WRITE,
-        smphdr.CommandId.SettingsManagement.DELETE_SETTING,
-        {"name": "example"},
+    frame = assert_frame(
+        smpset.DeleteSettingRequest(name="example"),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.DELETE_SETTING,
     )
-    assert r.name == "example"
+    assert frame.data.name == "example"
 
 
 def test_DeleteSettingResponse() -> None:
-    _do_test(
-        smpset.DeleteSettingResponse,
-        smphdr.OP.WRITE_RSP,
-        smphdr.CommandId.SettingsManagement.DELETE_SETTING,
-        {},
+    assert_frame(
+        smpset.DeleteSettingResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.DELETE_SETTING,
     )
 
 
 def test_CommitSettingsRequest() -> None:
-    _do_test(
-        smpset.CommitSettingsRequest,
-        smphdr.OP.WRITE,
-        smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS,
-        {},
+    assert_frame(
+        smpset.CommitSettingsRequest(),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.COMMIT_SETTINGS,
     )
 
 
 def test_CommitSettingsResponse() -> None:
-    _do_test(
-        smpset.CommitSettingsResponse,
-        smphdr.OP.WRITE_RSP,
-        smphdr.CommandId.SettingsManagement.COMMIT_SETTINGS,
-        {},
+    assert_frame(
+        smpset.CommitSettingsResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.COMMIT_SETTINGS,
     )
 
 
 def test_LoadSettingsRequest() -> None:
-    _do_test(
-        smpset.LoadSettingsRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS,
-        {},
+    assert_frame(
+        smpset.LoadSettingsRequest(),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.LOAD_SAVE_SETTINGS,
     )
 
 
 def test_LoadSettingsResponse() -> None:
-    _do_test(
-        smpset.LoadSettingsResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS,
-        {},
+    assert_frame(
+        smpset.LoadSettingsResponse(),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.LOAD_SAVE_SETTINGS,
     )
 
 
 def test_SaveSettingsRequest() -> None:
-    _do_test(
-        smpset.SaveSettingsRequest,
-        smphdr.OP.WRITE,
-        smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS,
-        {},
+    assert_frame(
+        smpset.SaveSettingsRequest(),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.LOAD_SAVE_SETTINGS,
     )
 
 
 def test_SaveSettingsResponse() -> None:
-    _do_test(
-        smpset.SaveSettingsResponse,
-        smphdr.OP.WRITE_RSP,
-        smphdr.CommandId.SettingsManagement.LOAD_SAVE_SETTINGS,
-        {},
+    assert_frame(
+        smpset.SaveSettingsResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.SETTINGS_MANAGEMENT,
+        command_id=setcmd.LOAD_SAVE_SETTINGS,
     )

--- a/tests/test_shell_management.py
+++ b/tests/test_shell_management.py
@@ -2,70 +2,29 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import shell_management as smpshell
-from tests.helpers import make_assert_header
-
-if TYPE_CHECKING:
-    from pydantic import BaseModel
+from tests.helpers import assert_frame
 
 shellcmd = smphdr.CommandId.ShellManagement
 
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.ShellManagement,
-    data: dict[str, Any],
-    nested_model: type[BaseModel] | None = None,
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.SHELL_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            if type(v) is dict and nested_model is not None:
-                for k2, v2 in v.items():
-                    one_deep = getattr(r, k)
-                    assert isinstance(one_deep[k2], nested_model)
-                    assert v2 == one_deep[k2].model_dump()
-            else:
-                assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
-
-
 def test_ExecuteRequest() -> None:
-    r = _do_test(
-        smpshell.ExecuteRequest,
-        smphdr.OP.WRITE,
-        shellcmd.EXECUTE,
-        {"argv": ["echo", "Hello"]},
+    frame = assert_frame(
+        smpshell.ExecuteRequest(argv=["echo", "Hello"]),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.SHELL_MANAGEMENT,
+        command_id=shellcmd.EXECUTE,
     )
-    assert r.argv == ["echo", "Hello"]
+    assert frame.data.argv == ["echo", "Hello"]
 
 
 def test_ExecuteResponse() -> None:
-    r = _do_test(
-        smpshell.ExecuteResponse,
-        smphdr.OP.WRITE_RSP,
-        shellcmd.EXECUTE,
-        {"o": "Hello", "ret": 0},
+    frame = assert_frame(
+        smpshell.ExecuteResponse(o="Hello", ret=0),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.SHELL_MANAGEMENT,
+        command_id=shellcmd.EXECUTE,
     )
-    assert r.o == "Hello"
-    assert r.ret == 0
+    assert frame.data.o == "Hello"
+    assert frame.data.ret == 0

--- a/tests/test_statistics_management.py
+++ b/tests/test_statistics_management.py
@@ -1,79 +1,49 @@
-"""Test the SMP Shell Management group."""
+"""Test the SMP Statistics Management group."""
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import statistics_management as smpstat
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.StatisticsManagement,
-    data: dict[str, Any],
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(
-        smphdr.GroupId.STATISTICS_MANAGEMENT, op, command_id, len(cbor)
-    )
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
+statcmd = smphdr.CommandId.StatisticsManagement
 
 
 def test_GroupDataRequest() -> None:
-    r = _do_test(
-        smpstat.GroupDataRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.StatisticsManagement.GROUP_DATA,
-        {"name": "example"},
+    frame = assert_frame(
+        smpstat.GroupDataRequest(name="example"),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.STATISTICS_MANAGEMENT,
+        command_id=statcmd.GROUP_DATA,
     )
-    assert r.name == "example"
+    assert frame.data.name == "example"
 
 
 def test_GroupDataResponse() -> None:
-    r = _do_test(
-        smpstat.GroupDataResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.StatisticsManagement.GROUP_DATA,
-        {"name": "example", "fields": {"field1": 1, "field2": 2}},
+    frame = assert_frame(
+        smpstat.GroupDataResponse(name="example", fields={"field1": 1, "field2": 2}),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.STATISTICS_MANAGEMENT,
+        command_id=statcmd.GROUP_DATA,
     )
-    assert r.name == "example"
-    assert r.fields == {"field1": 1, "field2": 2}
+    assert frame.data.name == "example"
+    assert frame.data.fields == {"field1": 1, "field2": 2}
 
 
 def test_ListOfGroupsRequest() -> None:
-    _do_test(
-        smpstat.ListOfGroupsRequest,
-        smphdr.OP.READ,
-        smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS,
-        {},
+    assert_frame(
+        smpstat.ListOfGroupsRequest(),
+        op=smphdr.OP.READ,
+        group_id=smphdr.GroupId.STATISTICS_MANAGEMENT,
+        command_id=statcmd.LIST_OF_GROUPS,
     )
 
 
 def test_ListOfGroupsResponse() -> None:
-    r = _do_test(
-        smpstat.ListOfGroupsResponse,
-        smphdr.OP.READ_RSP,
-        smphdr.CommandId.StatisticsManagement.LIST_OF_GROUPS,
-        {"stat_list": ("example1", "example2")},
+    frame = assert_frame(
+        smpstat.ListOfGroupsResponse(stat_list=("example1", "example2")),
+        op=smphdr.OP.READ_RSP,
+        group_id=smphdr.GroupId.STATISTICS_MANAGEMENT,
+        command_id=statcmd.LIST_OF_GROUPS,
     )
-    assert r.stat_list == ("example1", "example2")
+    assert frame.data.stat_list == ("example1", "example2")

--- a/tests/test_zephyr_management.py
+++ b/tests/test_zephyr_management.py
@@ -2,56 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
-
-import cbor2
-
 from smp import header as smphdr
-from smp import message as smpmsg
 from smp import zephyr_management as smpz
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
 
 zephyrcmd = smphdr.CommandId.ZephyrManagement
 
-T = TypeVar("T", bound=smpmsg._MessageBase)
-
-
-def _do_test(
-    msg: type[T],
-    op: smphdr.OP,
-    command_id: smphdr.CommandId.ZephyrManagement,
-    data: dict[str, Any],
-) -> T:
-    cbor = cbor2.dumps(data, canonical=True)
-    assert_header = make_assert_header(smphdr.GroupId.ZEPHYR_MANAGEMENT, op, command_id, len(cbor))
-
-    def _assert_common(r: smpmsg._MessageBase) -> None:
-        assert_header(r)
-        for k, v in data.items():
-            assert v == getattr(r, k)
-        assert cbor == r.BYTES[8:]
-
-    r = msg(**data)
-
-    _assert_common(r)  # serialize
-    _assert_common(msg.loads(r.BYTES))  # deserialize
-
-    return r
-
 
 def test_EraseStorageRequest() -> None:
-    _do_test(
-        smpz.EraseStorageRequest,
-        smphdr.OP.WRITE,
-        zephyrcmd.ERASE_STORAGE,
-        {},
+    assert_frame(
+        smpz.EraseStorageRequest(),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.GroupId.ZEPHYR_MANAGEMENT,
+        command_id=zephyrcmd.ERASE_STORAGE,
     )
 
 
 def test_EraseStorageResponse() -> None:
-    _do_test(
-        smpz.EraseStorageResponse,
-        smphdr.OP.WRITE_RSP,
-        zephyrcmd.ERASE_STORAGE,
-        {},
+    assert_frame(
+        smpz.EraseStorageResponse(),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.GroupId.ZEPHYR_MANAGEMENT,
+        command_id=zephyrcmd.ERASE_STORAGE,
     )

--- a/tests/user/test_intercreate.py
+++ b/tests/user/test_intercreate.py
@@ -1,66 +1,43 @@
 """Test the SMP Intercreate Management group."""
 
+from smp import header as smphdr
 from smp.user import intercreate as ic
-from tests.helpers import make_assert_header
+from tests.helpers import assert_frame
 
 
 def test_initial_ImageUploadWriteRequest() -> None:
-    r = ic.ImageUploadWriteRequest(
-        off=0,
-        data=b"test",
-        image=0,
-        len=132000,
-        sha=b"sha",
+    frame = assert_frame(
+        ic.ImageUploadWriteRequest(off=0, data=b"test", image=0, len=132000, sha=b"sha"),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.UserGroupId.INTERCREATE,
+        command_id=smphdr.CommandId.Intercreate.UPLOAD,
     )
-
-    assert_header = make_assert_header(
-        ic.header.UserGroupId.INTERCREATE,
-        ic.header.OP.WRITE,
-        ic.header.CommandId.Intercreate.UPLOAD,
-        len(r.BYTES) - ic.header.Header.SIZE,
-    )
-
-    assert_header(r)
-
-    assert r.off == 0
-    assert r.data == b"test"
-    assert r.image == 0
-    assert r.len == 132000
-    assert r.sha == b"sha"
+    assert frame.data.off == 0
+    assert frame.data.data == b"test"
+    assert frame.data.image == 0
+    assert frame.data.len == 132000
+    assert frame.data.sha == b"sha"
 
 
 def test_subsequent_ImageUploadWriteRequest() -> None:
-    r = ic.ImageUploadWriteRequest(
-        off=105000,
-        data=b"test",
+    frame = assert_frame(
+        ic.ImageUploadWriteRequest(off=105000, data=b"test"),
+        op=smphdr.OP.WRITE,
+        group_id=smphdr.UserGroupId.INTERCREATE,
+        command_id=smphdr.CommandId.Intercreate.UPLOAD,
     )
-
-    assert_header = make_assert_header(
-        ic.header.UserGroupId.INTERCREATE,
-        ic.header.OP.WRITE,
-        ic.header.CommandId.Intercreate.UPLOAD,
-        len(r.BYTES) - ic.header.Header.SIZE,
-    )
-
-    assert_header(r)
-
-    assert r.off == 105000
-    assert r.data == b"test"
-    assert r.image is None
-    assert r.len is None
-    assert r.sha is None
+    assert frame.data.off == 105000
+    assert frame.data.data == b"test"
+    assert frame.data.image is None
+    assert frame.data.len is None
+    assert frame.data.sha is None
 
 
 def test_ImageUploadWriteResponse() -> None:
-    r = ic.ImageUploadWriteResponse(sequence=0, off=105000)
-
-    assert_header = make_assert_header(
-        ic.header.UserGroupId.INTERCREATE,
-        ic.header.OP.WRITE_RSP,
-        ic.header.CommandId.Intercreate.UPLOAD,
-        len(r.BYTES) - ic.header.Header.SIZE,
+    frame = assert_frame(
+        ic.ImageUploadWriteResponse(off=105000),
+        op=smphdr.OP.WRITE_RSP,
+        group_id=smphdr.UserGroupId.INTERCREATE,
+        command_id=smphdr.CommandId.Intercreate.UPLOAD,
     )
-
-    assert_header(r)
-
-    assert r.off == 105000
+    assert frame.data.off == 105000

--- a/uv.lock
+++ b/uv.lock
@@ -1997,6 +1997,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "typing-extensions" },
 ]
 doc = [
     { name = "mike" },
@@ -2021,6 +2022,7 @@ dev = [
     { name = "pytest", specifier = ">=9,<10" },
     { name = "pytest-cov", specifier = ">=7,<8" },
     { name = "ruff", specifier = ">=0.15,<1" },
+    { name = "typing-extensions", specifier = ">=4,<5" },
 ]
 doc = [
     { name = "mike", specifier = ">=2.1.3,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1089,6 +1089,75 @@ wheels = [
 ]
 
 [[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/38/d591d9f66d43d897ecbd249f2833665823d19c8b043f16619bc8343e23df/msgspec-0.21.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72d9cd03241b8b2edb2e12dcc66c500fa480d8cbd71a8bac105809d468882064", size = 195172, upload-time = "2026-04-12T21:43:45.062Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1a/6899188b5982ec1324e0c629b7801eed2db987f6634fab58abd9fc82d317/msgspec-0.21.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed2ab278200e743a1d2610a4e0c8fc74f6cecb8548544cdec43f927bd9265238", size = 188316, upload-time = "2026-04-12T21:43:46.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/95/7e591b4fa11fdbbf9891164473c23420a8c781ef553295abe416bf335f42/msgspec-0.21.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd677e3001fdfed9186de72eab434da2976303cd5eb9550921d3d0c3e3e168ce", size = 216565, upload-time = "2026-04-12T21:43:48.081Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/714feeaf3b84cf2027235681725593840153dedd2868578f9f2715e296bb/msgspec-0.21.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f667b90b37fad734a91671abd68e0d7f4d066862771b87e91c53996dcb7a9027", size = 222689, upload-time = "2026-04-12T21:43:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b9/4384243e814f2579e5205e17d170b9c1a30121afd1393298d904817a7fa7/msgspec-0.21.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:49880fd20fdbcfe1b793f07dd83f12572bab679c9800352c8b2240289aa46a06", size = 222343, upload-time = "2026-04-12T21:43:50.612Z" },
+    { url = "https://files.pythonhosted.org/packages/04/01/4b227d9c4057346271043632bad41979cf8c3dca372e41bb1f7d546395b2/msgspec-0.21.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ae0162e22849a5e91eaad907766525107523b0daea3df267a9fcb5ba4e0936ae", size = 225607, upload-time = "2026-04-12T21:43:52.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/27021d1c3e5da837743092a7b7a5e8818397e1f4c05ee8b068bd7d1fd78a/msgspec-0.21.1-cp310-cp310-win_amd64.whl", hash = "sha256:f041a2279f31e3a53319005e4d60ba77c085cfcbe394cdc7ce803c2d01fe9449", size = 188392, upload-time = "2026-04-12T21:43:53.384Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2b/daf7a8d6d7cf00e0dcd0439178b284ade701234abdcadf3385601da04fbd/msgspec-0.21.1-cp310-cp310-win_arm64.whl", hash = "sha256:1bf17cbd7b28a5dffc7e764c654eed8ccde5e0f1de7970628608304640d4ce4e", size = 174191, upload-time = "2026-04-12T21:43:54.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7f/bbc4e74cd33d316b75541149e4d35b163b63bce066530ae185a2ec3b5bfc/msgspec-0.21.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b504b6e7f7a22a24b27232b73034421692147865162daaec9f3bf62439007c87", size = 193131, upload-time = "2026-04-12T21:43:56.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/60/504886af1aaf854112663b842d5eea9a15d9588f9bf7d0d2df736424b84d/msgspec-0.21.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4692b7c1609155708c4418f88e92f63c13fdf08aa095c84bae82bad75b53389b", size = 186597, upload-time = "2026-04-12T21:43:57.242Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/54/d24ddeaa65b5278c9e67f48ce3c17a9831e8f3722f3c8322ee120aca22ef/msgspec-0.21.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3124010b3815451494c85ff345e693cb9fe5889cfcbbef39ed8622e0e72319c", size = 215158, upload-time = "2026-04-12T21:43:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/75/bb79c8b89a93ae23cd33c0d802373f16feaf9633f05d8af77091350dda0a/msgspec-0.21.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6badc03b9725352219cca017bfe71c61f2fbd0fb5982b410ac17c97c213deb30", size = 219856, upload-time = "2026-04-12T21:44:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/c5ca26b46f0ebbd3a6683695ef89396712cb9e4199fd1f0bc1dd968216b1/msgspec-0.21.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5d2d4116ebe3035a78d9ec76e99a9d64e5fa6d44fe61a9c5de7fd1acf54bcc69", size = 220314, upload-time = "2026-04-12T21:44:01.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/31/645a351c4285dce40ed6755c3dcc0aa648e26dacb20a98018fe2cce5e87b/msgspec-0.21.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1009f6715f5bff3b54d4ff5c7428ad96197e0534e1645b8e9b955890c84664", size = 223215, upload-time = "2026-04-12T21:44:02.884Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8bf15736a6dd3cb4f90c5467f6dc39197d2daaf10754490cdc0aa17b7312/msgspec-0.21.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6faffe5bb644ec884052679af4dfd776d4b5ca90e4a7ec7e7e319e4e6b93a6e", size = 188554, upload-time = "2026-04-12T21:44:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/29/cc7db3a165b62d16e64a83f82eccb79655055cb5bc1f60459a6f9d7c82f2/msgspec-0.21.1-cp311-cp311-win_arm64.whl", hash = "sha256:ee9e3f11fa94603f7d673bf795cfa31b549c4a2c723bc39b45beb1e7f5a3fb99", size = 174517, upload-time = "2026-04-12T21:44:05.66Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
+name = "msgspec-cbor"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cbor2" },
+    { name = "msgspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/6d/d74123817748e5588020ce55ad80b8c629bc29250e19fa4c1fe113879bf3/msgspec_cbor-0.2.0.tar.gz", hash = "sha256:4e340d01e533c9190998dd54a460d0c05306f1afb04eccedf77be1c3962c83b5", size = 114626, upload-time = "2026-07-15T23:07:03.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/eb/2da515d6356f972540178fefa09adad57a375604a2fdddbee3c81c7173bb/msgspec_cbor-0.2.0-py3-none-any.whl", hash = "sha256:87e506b067bc8a7a0ae60bc307f48f3258b0ace4bd349023ea97d5e6e857d48a", size = 4617, upload-time = "2026-07-15T23:07:02.12Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1915,7 +1984,8 @@ source = { editable = "." }
 dependencies = [
     { name = "cbor2" },
     { name = "crcmod" },
-    { name = "pydantic" },
+    { name = "msgspec" },
+    { name = "msgspec-cbor" },
 ]
 
 [package.dev-dependencies]
@@ -1938,7 +2008,8 @@ doc = [
 requires-dist = [
     { name = "cbor2", specifier = ">=6,<7" },
     { name = "crcmod", specifier = ">=1.7,<2" },
-    { name = "pydantic", specifier = ">=2.6,<3" },
+    { name = "msgspec", specifier = ">=0.21.1" },
+    { name = "msgspec-cbor", specifier = ">=0.2,<0.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was opened by `claude-opus-4-8` on behalf of @JPHutchins, who asked for a draft release PR from the `screaming-goblin` breaking-release trunk into `main` that carries the issue-closing keywords, flags the breaking change, and links the epic.

> [!CAUTION]
> **This is a BREAKING release.** It changes the public `smp` message API (pydantic → `msgspec`; flattened model → `Frame[T]`/`Data` composition). Downstreams — **smpclient**, **smpmgr** — must be updated in lockstep. Merging this to `main` is the breaking version bump.

## What this is

`screaming-goblin` is the breaking-release integration trunk for `smp` under the transport/message epic **intercreate/smpmgr#103**. Breaking work lands here (rebased onto `main` as non-breaking changes merge), and this **draft** PR is the staging point for the eventual release into `main`. Keep it in **draft** until the breaking set is complete and downstreams are ready.

## Included so far

- **Frame[T]/Data on msgspec** (#65, merged into `screaming-goblin`) — an SMP message is now `Frame[T] = (Header, Data[T])`; de/serialization moved from pydantic + `cbor2` to `msgspec.Struct` + `msgspec-cbor`. Byte-exact against all 27,435 binary regressions; cold import 312 ms → 87 ms (3.6×); `camas matrix` green on Python 3.10–3.14, coverage 100%.

## Also on this branch

- **#62** — smpclient's generic `SMPRequest`/`Response` types moved into `smp`, with requests bound to their responses and errors (#67).
- **#70** — the SMP client owns the sequence space; `to_frame(sequence)` takes it, typed `u8` (#71).
- **SMP group 11, transport management** — ported to `Frame`/`Data` on msgspec, rebased in from `main` where it shipped in 4.2.0 (#73). The wire format is unchanged: all 25 of its lock records reproduce byte for byte.

**#60** (Python 3.15) landed separately on `main` and is closed; the cbor2 block cleared.

## Closes

Closes #45
Closes #26
Closes #5
Closes #62
Closes #70

(Supersedes the pydantic-only attempt in #46.)

Part of the epic: intercreate/smpmgr#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq2MMZAtCoSitXj3GQ5Lcz

