### PR TITLE
test: regression for #45 — SMP payload may contain header/version/sequence/smp_data

### DIFF
--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,11 +2,14 @@
 
 from typing import Final
 
+import cbor2
 import msgspec
 import pytest
 
 import smp.header as smphdr
 import smp.image_management as smpimg
+import smp.message as smpmsg
+from tests.helpers import assert_frame
 
 
 def test_smpclient_41() -> None:
@@ -33,3 +36,53 @@ def test_smpclient_41() -> None:
 
     with pytest.raises((msgspec.ValidationError, KeyError)):
         smpimg.ImageManagementErrorV2.loads(RESPONSE)
+
+
+def test_smp_45() -> None:
+    """https://github.com/JPHutchins/smp/issues/45
+
+    An SMP message's CBOR payload may legitimately contain fields named
+    `header`, `version`, `sequence`, or `smp_data`. The flattened pre-`Frame`
+    design excluded those names from serialization, silently dropping them; the
+    payload is now a distinct `Data` struct, so the names survive a round trip.
+    """
+
+    USER_GROUP: Final = 0x1234
+    COLLIDING: Final = {"header", "version", "sequence", "smp_data"}
+
+    class CollidingReadResponse(smpmsg.ReadResponse, frozen=True):
+        _GROUP_ID = USER_GROUP
+        _COMMAND_ID = 0
+
+        header: int
+        version: str
+        sequence: int
+        smp_data: bytes
+
+    response = CollidingReadResponse(header=1, version="1.2.3", sequence=7, smp_data=b"\xde\xad")
+    assert set(cbor2.loads(bytes(response))) == COLLIDING
+
+    decoded = assert_frame(response, op=smphdr.OP.READ_RSP, group_id=USER_GROUP, command_id=0)
+    assert decoded.data == response
+    assert decoded.data.header == 1
+    assert decoded.data.version == "1.2.3"
+    assert decoded.data.sequence == 7
+    assert decoded.data.smp_data == b"\xde\xad"
+
+    assert decoded.header.version == smphdr.Version.V2
+    assert decoded.header.sequence == 0
+
+    class CollidingWriteRequest(smpmsg.WriteRequest, frozen=True):
+        _GROUP_ID = USER_GROUP
+        _COMMAND_ID = 0
+
+        header: int
+        version: str
+        sequence: int
+        smp_data: bytes
+
+    request = CollidingWriteRequest(header=2, version="4.5.6", sequence=9, smp_data=b"\xbe\xef")
+    assert set(cbor2.loads(bytes(request))) == COLLIDING
+    assert (
+        assert_frame(request, op=smphdr.OP.WRITE, group_id=USER_GROUP, command_id=0).data == request
+    )


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-4-8 on behalf of @JPHutchins. JP asked for a regression test, on top of the `screaming-goblin` rework, that proves #45 is genuinely fixed — i.e. that an SMP payload may now contain fields named `header`/`version`/`sequence`/`smp_data`.

Adds `test_smp_45` to `tests/test_regressions.py`.

**#45:** the flattened `_MessageBase` excluded payload fields named `header`, `version`, `sequence`, and `smp_data` from the CBOR SMP data, silently dropping them — which broke the reporter's server whose response carried a `version` field. The `Frame[T]`/`Data` composition on `screaming-goblin` separates the SMP header from the payload, so those names are just ordinary `Data` fields.

The test defines a user-group `ReadResponse` and `WriteRequest` whose payloads carry all four previously-excluded names, and asserts:
- all four keys are actually present in the encoded CBOR payload (`cbor2.loads`), and
- a byte-exact round trip via `assert_frame`, with the payload's own `version`/`sequence` independent of the SMP `Frame` header's `version`/`sequence`.

Gate green locally (format / lint / mypy / pyright + 100% coverage). This targets `screaming-goblin`; #45 closes when that branch lands on `main` (PR #66 already carries `Closes #45`).