### PR TITLE
breaking: the SMP client owns the sequence space (closes #70)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 "crcmod>=1.7,<2",
 "msgspec>=0.21.1",
 "msgspec-cbor>=0.2,<0.3",
+"types-bits>=0.2,<0.3",
 ]
 dynamic = ["version"]
 classifiers = [
@@ -81,6 +82,7 @@ quote-style = "preserve"
 
 [tool.mypy]
 disallow_untyped_defs = true
+warn_unused_ignores = true
 exclude = ['\.venv']
 
 [tool.pyright]

--- a/src/smp/__init__.py
+++ b/src/smp/__init__.py
@@ -58,9 +58,10 @@ mypy linting and by Pydantic at runtime.
 `to_frame()` synthesizes the SMP header for a payload and takes a few arguments
 that are common to all SMP messages.
 
--   `sequence` is required.  The sequence space belongs to the SMP client, which
-    is the only thing that can know which sequence numbers are in flight; it is
-    the caller's job to keep the value within the header's 8 bit field.
+-   `sequence` is required and is a `types_bits.u8`, so the header's 8 bit field
+    is enforced by your type checker rather than by a `struct.error` at runtime.
+    The sequence space belongs to the SMP client, which is the only thing that
+    can know which sequence numbers are in flight.
 -   `version` is the SMP version.  This defaults to `smp.header.Version.V2`.
 -   `flags` default to the flags of the message type.
 
@@ -104,6 +105,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
+    from types_bits import u8
+
     from smp import error as smperror
     from smp import header as smpheader
     from smp import message as smpmessage
@@ -129,5 +132,5 @@ class SMPRequest(Protocol[_TRep_co, _TEr1_co, _TEr2_co]):
     @property
     def _ErrorV2(self) -> type[_TEr2_co]: ...
     def to_frame(
-        self, sequence: int, version: smpheader.Version = ..., flags: smpheader.Flag | None = ...
+        self, sequence: u8, version: smpheader.Version = ..., flags: smpheader.Flag | None = ...
     ) -> smpmessage.Frame[Any]: ...

--- a/src/smp/__init__.py
+++ b/src/smp/__init__.py
@@ -55,14 +55,17 @@ mypy linting and by Pydantic at runtime.
 
 ## Serialization
 
-There are a few optional arguments that are common to all SMP messages when they
-are created.
+`to_frame()` synthesizes the SMP header for a payload and takes a few arguments
+that are common to all SMP messages.
 
--   `header` is the SMP header.  Typically this can be left as `None` and will be
-    so that the header is created automatically.
+-   `sequence` is required.  The sequence space belongs to the SMP client, which
+    is the only thing that can know which sequence numbers are in flight; it is
+    the caller's job to keep the value within the header's 8 bit field.
 -   `version` is the SMP version.  This defaults to `smp.header.Version.V2`.
--   `sequence` is the sequence number of the message.  If not provided, it will
-    be automatically generated using an incrementing counter.
+-   `flags` default to the flags of the message type.
+
+If you have already formed a header, pair it with its payload using `load()`
+rather than `to_frame()`.
 
 Take a look at `smp.message` for more information on the base classes.
 
@@ -102,6 +105,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from smp import error as smperror
+    from smp import header as smpheader
     from smp import message as smpmessage
 
 _TRep_co = TypeVar(
@@ -124,4 +128,6 @@ class SMPRequest(Protocol[_TRep_co, _TEr1_co, _TEr2_co]):
     def _ErrorV1(self) -> type[_TEr1_co]: ...
     @property
     def _ErrorV2(self) -> type[_TEr2_co]: ...
-    def to_frame(self) -> smpmessage.Frame[Any]: ...
+    def to_frame(
+        self, sequence: int, version: smpheader.Version = ..., flags: smpheader.Flag | None = ...
+    ) -> smpmessage.Frame[Any]: ...

--- a/src/smp/message.py
+++ b/src/smp/message.py
@@ -6,13 +6,16 @@ An SMP message is a `Frame`: an SMP `Header` and its CBOR payload `Data`.
 from __future__ import annotations
 
 from enum import IntEnum, unique
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 import msgspec
 import msgspec_cbor
 
 from smp import header as smpheader
 from smp.exceptions import SMPMalformed, SMPMismatchedGroupId
+
+if TYPE_CHECKING:
+    from types_bits import u8
 
 T = TypeVar("T", bound="Data")
 
@@ -37,7 +40,7 @@ class Data(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_field
 
     def to_frame(
         self: T,
-        sequence: int,
+        sequence: u8,
         version: smpheader.Version = smpheader.Version.V2,
         flags: smpheader.Flag | None = None,
     ) -> Frame[T]:

--- a/src/smp/message.py
+++ b/src/smp/message.py
@@ -5,7 +5,6 @@ An SMP message is a `Frame`: an SMP `Header` and its CBOR payload `Data`.
 
 from __future__ import annotations
 
-import itertools
 from enum import IntEnum, unique
 from typing import Any, ClassVar, Generic, TypeVar
 
@@ -14,8 +13,6 @@ import msgspec_cbor
 
 from smp import header as smpheader
 from smp.exceptions import SMPMalformed, SMPMismatchedGroupId
-
-_counter = itertools.count()
 
 T = TypeVar("T", bound="Data")
 
@@ -40,10 +37,9 @@ class Data(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_field
 
     def to_frame(
         self: T,
-        *,
+        sequence: int,
         version: smpheader.Version = smpheader.Version.V2,
         flags: smpheader.Flag | None = None,
-        sequence: int | None = None,
     ) -> Frame[T]:
         """Wrap this `Data` in a `Frame`, synthesizing the SMP `Header`."""
         payload = bytes(self)
@@ -54,7 +50,7 @@ class Data(msgspec.Struct, frozen=True, omit_defaults=True, forbid_unknown_field
                 flags=smpheader.Flag(self._FLAGS if flags is None else flags),
                 length=len(payload),
                 group_id=self._GROUP_ID,
-                sequence=next(_counter) % 0x100 if sequence is None else sequence,
+                sequence=sequence,
                 command_id=self._COMMAND_ID,
             ),
             self,

--- a/tests/binary_regressions/test_binary_lock.py
+++ b/tests/binary_regressions/test_binary_lock.py
@@ -12,6 +12,8 @@ import pytest
 from smp import header
 
 if TYPE_CHECKING:
+    from types_bits import u8
+
     from smp.message import Data
 
 pytestmark = pytest.mark.slow
@@ -20,7 +22,7 @@ pytestmark = pytest.mark.slow
 class Record(NamedTuple):
     message: str
     version: int
-    sequence: int
+    sequence: u8
     kwargs: dict[str, Any]
     bytes: str
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,7 +27,7 @@ def assert_frame(
     assert header.flags == flags
     assert header.group_id == group_id
     assert header.command_id == command_id
-    assert 0 <= header.sequence <= 0xFF
+    assert header.sequence == sequence
     assert 0 <= header.length <= 0xFFFF
     if length is not None:
         assert header.length == length

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from smp import header as smpheader
 from smp import message as smpmessage
+
+if TYPE_CHECKING:
+    from types_bits import u8
 
 T = TypeVar("T", bound=smpmessage.Data)
 
@@ -17,7 +20,7 @@ def assert_frame(
     length: int | None = None,
     version: smpheader.Version = smpheader.Version.V2,
     flags: smpheader.Flag = smpheader.Flag.UNUSED,
-    sequence: int = 0,
+    sequence: u8 = 0,
 ) -> smpmessage.Frame[T]:
     """Assert `data`'s header and a byte-exact round-trip; returns the decoded Frame."""
     frame = data.to_frame(version=version, flags=flags, sequence=sequence)

--- a/tests/test_generics_typing.py
+++ b/tests/test_generics_typing.py
@@ -18,6 +18,7 @@ from typing_extensions import assert_never, assert_type
 from smp import SMPRequest
 from smp import enumeration_management as enum
 from smp import file_management as fs
+from smp import header as smpheader
 from smp import image_management as img
 from smp import message as smpmessage
 from smp import os_management as os
@@ -58,6 +59,37 @@ def error(response: smpmessage.Response) -> TypeIs[smperror.ErrorV1 | smperror.E
 def _request(request: SMPRequest[TRep, TEr1, TEr2]) -> TRep | TEr1 | TEr2:
     """Stand-in for `smpclient.SMPClient.request` that drives the static checks."""
     raise NotImplementedError
+
+
+def _client_owned_frame(
+    request: SMPRequest[TRep, TEr1, TEr2],
+    *,
+    sequence: int,
+    version: smpheader.Version,
+    flags: smpheader.Flag,
+) -> smpmessage.Frame[Any]:
+    """An SMP client owning its sequence space and its SMP version.
+
+    The sequence space belongs to the client, so `SMPRequest` must expose the
+    header knobs that `Data.to_frame` accepts; hiding them forced every client
+    onto one process-global counter.
+    """
+    return request.to_frame(sequence, version=version, flags=flags)
+
+
+def _check_client_owned_frame() -> None:
+    _client_owned_frame(
+        os.EchoWriteRequest(d="hello"),
+        sequence=0,
+        version=smpheader.Version.V1,
+        flags=smpheader.Flag.UNUSED,
+    )
+    _client_owned_frame(
+        img.ImageStatesReadRequest(),
+        sequence=0xFF,
+        version=smpheader.Version.V2,
+        flags=smpheader.Flag.UNUSED,
+    )
 
 
 def _check_read_narrowing() -> None:

--- a/tests/test_generics_typing.py
+++ b/tests/test_generics_typing.py
@@ -29,6 +29,7 @@ from smp import zephyr_management as zephyr
 from smp.user import intercreate as ic
 
 if TYPE_CHECKING:
+    from types_bits import u8
     from typing_extensions import TypeIs
 
     from smp import error as smperror
@@ -64,7 +65,7 @@ def _request(request: SMPRequest[TRep, TEr1, TEr2]) -> TRep | TEr1 | TEr2:
 def _client_owned_frame(
     request: SMPRequest[TRep, TEr1, TEr2],
     *,
-    sequence: int,
+    sequence: u8,
     version: smpheader.Version,
     flags: smpheader.Flag,
 ) -> smpmessage.Frame[Any]:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,8 +1,10 @@
 """Tests for user-defined inheritance of classes."""
 
+from __future__ import annotations
+
 import struct
 from enum import IntEnum
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -11,6 +13,9 @@ from smp import image_management as smpimg
 from smp import message as smpmsg
 from smp import os_management as smpos
 from smp.exceptions import SMPMalformed, SMPMismatchedGroupId
+
+if TYPE_CHECKING:
+    from types_bits import u8
 
 USER_GROUP_ID_MIN: Final = 64
 
@@ -118,7 +123,7 @@ def test_invalid_command_id() -> None:
 
 
 @pytest.mark.parametrize("sequence", [0, 1, 0x2A, 0xFF])
-def test_to_frame_sequence_is_caller_owned(sequence: int) -> None:
+def test_to_frame_sequence_is_caller_owned(sequence: u8) -> None:
     """The caller's sequence reaches the wire verbatim; `smp` never assigns one."""
     frame = smpimg.ImageStatesReadRequest().to_frame(sequence)
     assert frame.header.sequence == sequence
@@ -132,8 +137,9 @@ def test_to_frame_requires_sequence() -> None:
 
 @pytest.mark.parametrize("sequence", [-1, 0x100])
 def test_to_frame_rejects_out_of_range_sequence(sequence: int) -> None:
+    """`u8` rejects these statically; an unchecked caller still fails at `struct`."""
     with pytest.raises(struct.error):
-        smpimg.ImageStatesReadRequest().to_frame(sequence=sequence)
+        smpimg.ImageStatesReadRequest().to_frame(sequence)  # type: ignore[arg-type]
 
 
 def test_loads_rejects_mismatched_group_id() -> None:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -117,6 +117,25 @@ def test_invalid_command_id() -> None:
         B().to_frame(sequence=0)
 
 
+@pytest.mark.parametrize("sequence", [0, 1, 0x2A, 0xFF])
+def test_to_frame_sequence_is_caller_owned(sequence: int) -> None:
+    """The caller's sequence reaches the wire verbatim; `smp` never assigns one."""
+    frame = smpimg.ImageStatesReadRequest().to_frame(sequence)
+    assert frame.header.sequence == sequence
+    assert smpimg.ImageStatesReadRequest.loads(bytes(frame)) == frame
+
+
+def test_to_frame_requires_sequence() -> None:
+    with pytest.raises(TypeError):
+        smpimg.ImageStatesReadRequest().to_frame()  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize("sequence", [-1, 0x100])
+def test_to_frame_rejects_out_of_range_sequence(sequence: int) -> None:
+    with pytest.raises(struct.error):
+        smpimg.ImageStatesReadRequest().to_frame(sequence=sequence)
+
+
 def test_loads_rejects_mismatched_group_id() -> None:
     wire = bytes(smpimg.ImageStatesReadRequest().to_frame(sequence=0))
     with pytest.raises(SMPMismatchedGroupId):

--- a/uv.lock
+++ b/uv.lock
@@ -6,8 +6,8 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
@@ -1986,6 +1986,7 @@ dependencies = [
     { name = "crcmod" },
     { name = "msgspec" },
     { name = "msgspec-cbor" },
+    { name = "types-bits" },
 ]
 
 [package.dev-dependencies]
@@ -2011,6 +2012,7 @@ requires-dist = [
     { name = "crcmod", specifier = ">=1.7,<2" },
     { name = "msgspec", specifier = ">=0.21.1" },
     { name = "msgspec-cbor", specifier = ">=0.2,<0.3" },
+    { name = "types-bits", specifier = ">=0.2,<0.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -2146,6 +2148,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
     { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
     { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
+]
+
+[[package]]
+name = "types-bits"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/f6/2a6f942fd4b9324fa2cead74f7b85a21ccbdd0ddddce6de87bf00ac528e7/types_bits-0.2.0.tar.gz", hash = "sha256:0e9a45d6614551043880e5f47c70981b39d78bc1c2a018d1ad4324bccf60079c", size = 119348, upload-time = "2026-08-28T22:19:19.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/41/cf41a0415d18b66378abc956034e417acccef3462888c173c8d53ed4ff87/types_bits-0.2.0-py3-none-any.whl", hash = "sha256:810b8e773b0ffd80fb589185abc21641fddba234a8ebbb7ce55f3f5d6dc8cf6d", size = 13716, upload-time = "2026-08-28T22:19:18.886Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by `claude-opus-5[1m]` on behalf of @JPHutchins, who asked for a branch and PR for #70 based on `screaming-goblin`. I asked which of the issue's two scopes to take; @JPHutchins chose to widen the Protocol **and** drop the module-global counter while the breaking window is open, then revised the signature so `sequence` is positional rather than keyword-only, and asked for `sequence` to be typed as `u8` via [types-bits](https://pypi.org/project/types-bits/).

Closes #70. Base is `screaming-goblin`.

## Summary

`SMPRequest.to_frame()` declared no parameters, so a client programming against the Protocol could not pass `sequence` — even though `Data.to_frame()` has always accepted it. `SMPClient.request()` takes an `SMPRequest`, so every client was structurally forced onto the module-global `itertools.count()` in `smp/message.py`.

1. **`SMPRequest.to_frame()` now declares `sequence`, `version`, and `flags`,** matching `Data.to_frame()`. This is the fix #70 asks for; the same gap hid `version`, which intercreate/smpclient#126 needs to expose an SMP version on the convenience methods.
2. **Breaking — `_counter` is gone and `sequence` is required.** The sequence space belongs to one `smpclient.SMPClient` per connection, not to a counter shared by every caller in the process.

3. **`sequence` is typed `u8`,** so the header's 8 bit field is enforced by the type checker rather than by a `struct.error` at pack time.

`sequence` is positional-or-keyword and leads the signature. **Wire format is unchanged**; all binary regressions stay byte-exact.

## The change

```diff
  # src/smp/__init__.py — the SMPRequest Protocol
- def to_frame(self) -> smpmessage.Frame[Any]: ...
+ def to_frame(
+     self, sequence: u8, version: smpheader.Version = ..., flags: smpheader.Flag | None = ...
+ ) -> smpmessage.Frame[Any]: ...
```

```diff
  # src/smp/message.py — Data
- _counter = itertools.count()
-
      def to_frame(
          self: T,
-         *,
+         sequence: u8,
          version: smpheader.Version = smpheader.Version.V2,
          flags: smpheader.Flag | None = None,
-         sequence: int | None = None,
      ) -> Frame[T]:
...
-                 sequence=next(_counter) % 0x100 if sequence is None else sequence,
+                 sequence=sequence,
```

## Migration

The counter moves to the caller — and because `sequence` is `u8`, masking alone does **not** satisfy the checkers. Narrow once at the boundary:

```diff
+ if TYPE_CHECKING:
+     from types_bits import u8
+
  class SMPClient:
      def __init__(self, ...) -> None:
+         self._counter = itertools.count()
+
+     def _next_sequence(self) -> u8:
+         return cast("u8", next(self._counter) % 0x100)

-     request.to_frame()
+     request.to_frame(self._next_sequence())
```

Literals need nothing — `request.to_frame(0xFF)` type-checks as-is. A plain `int` does not, masked or otherwise:

```
request.to_frame(next(self._counter) % 0x100)

mypy: error: Argument 1 to "to_frame" of "SMPRequest" has incompatible type "int";
      expected "u8"  [arg-type]
```

Every call site in this repo already passed `sequence` explicitly, so the diff outside the two signatures is tests only.

<details>
<summary><b>Why drop the global rather than just bypass it</b></summary>

Widening the Protocol alone (option 1 in #70) would have been enough to unblock smpclient — with `sequence` exposed, smpclient stops using the default anyway. The global was dropped because leaving it costs another breaking cycle later, and it is process-global mutable state:

- with N concurrent clients the 8 bit sequence space is consumed N times as fast;
- no caller can reason about "my next sequence", which is what the resync/retry work downstream needs (intercreate/smpclient#56, intercreate/smpclient#104, intercreate/smpclient#129);
- sequences from different clients interleave, so a client's own sequences are not monotonic.

There is no natural instance in `smp` to own a counter — a `Data` is one message, and `smp` has no session or connection object — so ownership moves downstream to the entity whose sequence space it actually is.

Out-of-range values still fail at the `struct` boundary; **no new validation is introduced**. The `% 0x100` wrap the counter used to apply is now the caller's responsibility, which is what the queued `u8` work below makes checkable.

</details>

<details>
<summary><b>Keeping the two signatures in lockstep</b></summary>

`Data.to_frame` and `SMPRequest.to_frame` must stay identical in *arity and calling convention*, not just in types: because the Protocol accepts `sequence` positionally, a keyword-only `Data.to_frame` would stop structurally conforming and every concrete request would fail the `SMPRequest` bound.

`tests/test_generics_typing.py` guards this by passing `sequence` **positionally** through the Protocol and then calling it with concrete request types:

```python
def _client_owned_frame(
    request: SMPRequest[TRep, TEr1, TEr2],
    *,
    sequence: int,
    version: smpheader.Version,
    flags: smpheader.Flag,
) -> smpmessage.Frame[Any]:
    return request.to_frame(sequence, version=version, flags=flags)
```

That file is checked by both mypy and pyright under the `typecheck` task, so drift between the two signatures fails CI rather than silently un-binding the Protocol.

</details>

<details>
<summary><b>Verification</b></summary>

**The issue's own repro, before → at HEAD.** #70's `client_owned_sequence` could not be written at all; it now can, with the client owning its `u8` sequence space:

```python
class Client:
    def _next_sequence(self) -> u8:
        return cast("u8", next(self._counter) % 0x100)

    def request(self, request: SMPRequest[Any, Any, Any]) -> Frame[Any]:
        return request.to_frame(self._next_sequence())
```

```
# before (verbatim from #70)
mypy:    error: Unexpected keyword argument "sequence" for "to_frame" of "SMPRequest"  [call-arg]
pyright: error: No parameter named "sequence"  (reportCallIssue)

# at HEAD — clean on both
$ mypy repro.py     ->  Success: no issues found in 1 source file
$ pyright repro.py  ->  0 errors, 0 warnings, 0 informations
```

**And the removed default is now an error, on both checkers:**

```
repro_fail.py:12: error: Missing positional argument "sequence" in call to "to_frame" of "SMPRequest"  [call-arg]
repro_fail.py:16: error: Missing named argument "sequence" for "to_frame" of "Data"  [call-arg]

repro_fail.py:12:12 - error: Argument missing for parameter "sequence" (reportCallIssue)
repro_fail.py:16:12 - error: Argument missing for parameter "sequence" (reportCallIssue)
```

**Tests added** — `tests/test_message.py` covers the positive and negative cases of the new contract: the sequence reaches the wire verbatim (`0`, `1`, `0x2A`, `0xFF`), omitting it is a `TypeError`, and out-of-range still raises `struct.error`. `assert_frame` now asserts `header.sequence == sequence` rather than a range — the range check existed only because the library, not the caller, produced the value.

**`camas gate`** — green: `format_check`, `lint`, `mypy`, `pyright`, `coverage` (100%, `fail_under = 100`).

**`camas matrix`** — fully green: `format_check`, `lint`, `mypy`, `pyright`, and `test` on every one of Python 3.10, 3.11, 3.12, 3.13, 3.14, and 3.15 (30/30 tasks, exit 0).

</details>

<details>
<summary><b><code>u8</code> and the types-bits dependency</b></summary>

`types_bits.u8` is a fully materialized `Literal` union shipped as a `.pyi`, so this is a type-checker-only construct — the import sits under `TYPE_CHECKING` in both modules and never executes:

```
request.to_frame(0x100)

mypy:    error: Argument 1 to "to_frame" has incompatible type "Literal[256]";
         expected "Literal[0, 1, ..., 255]"  [arg-type]
pyright: error: Argument of type "Literal[256]" cannot be assigned to parameter
         "sequence"  (reportArgumentType)
```

It is a **`[project]` dependency, not a dev dependency** — `u8` appears in `smp`'s public signatures and `smp` ships `py.typed`, so downstream checkers must be able to resolve it.

**Why 0.2.0 specifically.** 0.1.0 was blocked twice over: it declared `Requires-Python: >=3.12` against smp's `>=3.10`, *and* its stub used PEP 695 `type u8 = ...`, which mypy rejects outright whenever `--python-version` is below 3.12 (`error: Type statement is only supported in Python 3.12 and greater [syntax]`, "errors prevented further checking"). The 3.10 and 3.11 matrix legs would have failed even with the floor lowered. 0.2.0 lowers the floor **and** emits `u8: TypeAlias = Literal[...]`.

**Typecheck cost: none measurable.** Cold mypy over `src tests` on 3.10, cache cleared between runs — 6.24s before this commit, 4.83s after.

</details>

<details>
<summary><b><code>warn_unused_ignores</code></b></summary>

Enabled for mypy so the `u8` annotation is load-bearing rather than decorative. `test_to_frame_rejects_out_of_range_sequence` covers the unchecked caller by passing `-1` and `0x100` behind a `type: ignore[arg-type]`. With the flag on, reverting `sequence: u8` back to `int` makes that ignore unused and fails the `typecheck` task — verified by doing exactly that:

```
tests/test_message.py:142: error: Unused "type: ignore" comment  [unused-ignore]
```

The repo was already clean under the flag otherwise, so nothing else needed touching.

</details>

<details>
<summary><b>Follow-ups, not in this PR</b></summary>

- **The `smp` module docstring is still Pydantic-era** and wrong in ways this PR did not introduce: it says messages "are represented as Pydantic models" with a `header` attribute, and its `print(bytes(request))` example shows a full framed message with an 8 byte header, whereas `bytes(Data)` is now the CBOR payload alone. Only the `sequence` bullet — falsified by *this* change — was touched here. Worth its own issue.
- **`command_id` is the other 8 bit field** `u8` would fit — same shape as `sequence`: an unbounded `int` arm in `AnyCommandId`, guarded only by `struct.error` at runtime. Not included here pending a call on it. `length` and `group_id` are 16 bit and out of reach while `types-bits` ships `u1..u10` (`MAX_BITS = 10`).
- **`Header.sequence` is still `int`.** Typing the dataclass field would need a cast at the `Header.loads()` / `struct.unpack` boundary.

</details>
